### PR TITLE
remove broken docs/RUNNING.md link

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,6 @@ to the following fetch/update cycle.
 
 ## Documentation
 
-- How to [run](docs/RUNNING.md) repology tools on your own
 - How to extend or fix [rules](https://github.com/repology/repology-rules/blob/master/README.md) for package matching
 - How repology [compares versions](https://github.com/repology/libversion/blob/master/doc/ALGORITHM.md)
 


### PR DESCRIPTION
Remove the (broken) docs/RUNNING.md link since running
instructions are already in the README.

Signed-off-by: Jeremiah Mahler <jmmahler@gmail.com>