### PR TITLE
Add Amazon Linux distribution

### DIFF
--- a/repos.d/rpm/amazonlinux.yaml
+++ b/repos.d/rpm/amazonlinux.yaml
@@ -1,0 +1,30 @@
+- name: amazon_2
+  type: repository
+  desc: Amazon Linux 2
+  family: fedora
+  minpackages: 2000
+  sources:
+    - name: core
+      fetcher: RepodataSqliteFetcher
+      parser: RepodataSqliteParser
+      url: http://amazonlinux.us-west-2.amazonaws.com/2/core/2.0/SRPMS/mirror.list
+  repolinks:
+    - desc: Amazon Linux 2
+      url: https://aws.amazon.com/amazon-linux-2/
+  tags: [ all, production, rpm, amazon ]
+
+- name: amazon_1
+  type: repository
+  desc: Amazon Linux 1
+  family: fedora
+  minpackages: 2000
+  sources:
+    - name: [ main, updates ]
+      fetcher: RepodataSqliteFetcher
+      parser: RepodataSqliteParser
+      url: 'http://repo.us-west-2.amazonaws.com/latest/{source}/SRPMS/mirror.list'
+      subrepo: '{source}'
+  repolinks:
+    - desc: Amazon Linux AMI
+      url: https://aws.amazon.com/amazon-linux-ami/
+  tags: [ all, production, rpm, amazon ]


### PR DESCRIPTION
Adds the Amazon Linux distribition (both AL1 and AL2).

### Testing

Ran repology-update.py and confirmed results in repology-webapp looks reasonable.

```
alosdev:repology-updater$ sudo -u repology ./repology-update.py --fetch --fetch --parse --database --postupdate --repositories amazonlinux
```