### PR TITLE
Add Gentoo GURU overlay

### DIFF
--- a/repos.d/gentoo/overlays.yaml
+++ b/repos.d/gentoo/overlays.yaml
@@ -1,4 +1,35 @@
 ###########################################################################
+# GURU
+###########################################################################
+- name: gentoo_ovl_guru
+  type: repository
+  desc: Gentoo overlay GURU
+  family: gentoo
+  color: '62548f'
+  minpackages: 100
+  default_maintainer: guru@gentoo.org
+  sources:
+    - name: guru-overlay
+      fetcher: GitFetcher
+      parser: GentooGitParser
+      require_md5cache_metadata: true
+      require_xml_metadata: false
+      url: https://github.com/gentoo-mirror/guru.git
+  repolinks:
+    - desc: Gentoo wiki page for Project GURU
+      url: https://wiki.gentoo.org/wiki/Project:GURU
+    - desc: Git repository
+      url: https://gitweb.gentoo.org/repo/proj/guru.git
+    - desc: Github sync repository mirror
+      url: https://github.com/gentoo-mirror/guru
+  packagelinks:
+    - desc: Package details
+      url: 'https://gpo.zugaina.org/Overlays/guru/{srcname}'
+    - desc: View ebuild
+      url: 'https://gitweb.gentoo.org/repo/proj/guru.git/tree/{srcname}/{srcname|basename}-{rawversion}.ebuild'
+  tags: [ all, production, gentoo-overlays ]
+
+###########################################################################
 # Pentoo
 ###########################################################################
 - name: gentoo_ovl_pentoo


### PR DESCRIPTION
As stated in [1] "the goal of the GURU project is to create an official
repository of new Gentoo packages that are maintained collaboratively
by Gentoo users".

"GURU is an official Gentoo project, and is therefore bound
by the official Gentoo policies".

The official detailed article about project is available [2] too.

[1] https://wiki.gentoo.org/wiki/Project:GURU
[2] https://dev.gentoo.org/~mgorny/articles/guru-a-new-model-of-contributing-to-gentoo.html

P.S.
The `tags: ` doesn't include `production` currently.