### PR TITLE
Fix Fedora 31 release name

### DIFF
--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -185,7 +185,7 @@
   color: '294172'
   minpackages: 20000
   sources:
-    - name: development
+    - name: release
       fetcher: RepodataFetcher
       parser: RepodataParser
       url: https://mirror.yandex.ru/fedora/linux/releases/31/Everything/source/tree/


### PR DESCRIPTION
I think that this only changes the displayed name from development to release, if it has any unwanted side effects this should probably not be merged. 

With the change the naming matches the naming scheme of the other Fedora repositories in repology and of course the actual purpose of this repository (it contains the packages of the release and has not been updated since then).