### PR TITLE
Add link to git of openEuler packages

### DIFF
--- a/repos.d/rpm/openeuler.yaml
+++ b/repos.d/rpm/openeuler.yaml
@@ -17,4 +17,7 @@
   repolinks:
     - desc: openEuler home
       url: https://openeuler.org/en/
+  packagelinks:
+    - desc: Package git
+      url: 'https://gitee.com/src-openeuler/{srcname}/tree/openEuler-20.03-LTS/'
   tags: [ all, production, openeuler, rpm ]


### PR DESCRIPTION
Note: I'm not sure that SRPM name and the name of git repo always match there,
for example: java-1.8.0-openjdk-1.8.0.242.b08-1.h5.oe1.src.rpm vs https://gitee.com/src-openeuler/openjdk-1.8.0