### PR TITLE
Add repository KISS Games

### DIFF
--- a/repos.d/kiss-games.yaml
+++ b/repos.d/kiss-games.yaml
@@ -1,0 +1,24 @@
+###########################################################################
+# KISS Linux Games
+###########################################################################
+- name: kiss_games
+  type: repository
+  desc: KISS Linux Games
+  family: kiss
+  ruleset: kiss
+  minpackages: 30
+  sources:
+    - name: repo
+      fetcher: GitFetcher
+      parser: KissGitParser
+      url: 'https://github.com/sdsddsd1/kiss-games.git'
+      maintainer_from_git: true
+      depth: null
+      sparse_checkout: [ '**/version', '**/sources' ]
+  repolinks:
+    - desc: Main Repositories on GitHub
+      url: https://github.com/sdsddsd1/kiss-games
+  packagelinks:
+    - desc: Package directory on GitHub
+      url: 'https://github.com/sdsddsd1/kiss-games/tree/master/{path}'
+  tags: [ all, production, kiss ]


### PR DESCRIPTION
As this is a community repository, it is best left in it's own file rather than in kiss.yaml.

It may be better to put kiss.yaml and kiss-games.yaml in their own folder, if this works let me know.