### PR TITLE
Updated CRUX parser class and repository config to use a JSON dump ra…

### DIFF
--- a/repology/parsers/parsers/crux.py
+++ b/repology/parsers/parsers/crux.py
@@ -20,9 +20,10 @@ from typing import Iterable
 from repology.logger import Logger
 from repology.packagemaker import NameType, PackageFactory, PackageMaker
 from repology.parsers import Parser
-from repology.parsers.maintainers import extract_maintainers
 from repology.parsers.json import iter_json_list
+from repology.parsers.maintainers import extract_maintainers
 from repology.transformer import PackageTransformer
+
 
 class CRUXPortsJsonParser(Parser):
     def iter_parse(self, path: str, factory: PackageFactory, transformer: PackageTransformer) -> Iterable[PackageMaker]:

--- a/repology/parsers/parsers/crux.py
+++ b/repology/parsers/parsers/crux.py
@@ -38,5 +38,6 @@ class CRUXPortsJsonParser(Parser):
                     pkg.add_maintainers(extract_maintainers(port['maintainer']))
                 pkg.add_homepages(port['url'])
                 pkg.set_subrepo(port['repository'])
+                pkg.add_downloads(port['sources'])
 
                 yield pkg

--- a/repos.d/crux.yaml
+++ b/repos.d/crux.yaml
@@ -3,20 +3,52 @@
 #
 # https://crux.nu/ports/
 ###########################################################################
-- name: crux
+- name: crux_34
   type: repository
-  desc: CRUX
+  desc: CRUX 3.4
+  statsgroup: CRUX
   family: crux
+  ruleset: crux
   minpackages: 1000
   update_period: 6h
   sources:
     - name: CRUX-ports-JSON
       fetcher: FileFetcher
       parser: CRUXPortsJsonParser
-      url: https://crux.ninja/portdb/repology/
+      url: https://crux.nu/files/repology-3.4.json
   repolinks:
     - desc: CRUX home
       url: https://crux.nu/
     - desc: CRUX port browser
       url: https://crux.nu/portdb/
+  packagelinks:
+    - desc: Port Directory
+      url: 'https://crux.nu/ports/crux-3.4/{subrepo}/{name}/'
+    - desc: Pkgfile
+      url: 'https://crux.nu/ports/crux-3.4/{subrepo}/{name}/Pkgfile'
+  tags: [ all, production, crux ]
+
+- name: crux_35
+  type: repository
+  desc: CRUX 3.5
+  statsgroup: CRUX
+  family: crux
+  ruleset: crux
+  minpackages: 1000
+  update_period: 6h
+  sources:
+    - name: CRUX-ports-JSON
+      fetcher: FileFetcher
+      parser: CRUXPortsJsonParser
+      url: https://crux.nu/files/repology-3.5.json
+  repolinks:
+    - desc: CRUX home
+      url: https://crux.nu/
+    - desc: CRUX port browser
+      url: https://crux.nu/portdb/
+  packagelinks:
+    - desc: Port Directory
+      url: 'https://crux.nu/ports/crux-3.5/{subrepo}/{name}/'
+    - desc: Pkgfile
+      url: 'https://crux.nu/ports/crux-3.5/{subrepo}/{name}/Pkgfile'
   tags: [ all, production, crux ]

--- a/repos.d/crux.yaml
+++ b/repos.d/crux.yaml
@@ -3,98 +3,20 @@
 #
 # https://crux.nu/ports/
 ###########################################################################
-- name: crux_32
+- name: crux
   type: repository
-  desc: CRUX 3.2
-  statsgroup: CRUX
+  desc: CRUX
   family: crux
   minpackages: 1000
+  update_period: 6h
   sources:
-    - name: [ core, opt, xorg, contrib ]
-      fetcher: RsyncFetcher
-      parser: CRUXParser
-      url: 'crux.nu::ports/{source}/3.2/'
-      subrepo: '{source}'
+    - name: CRUX-ports-JSON
+      fetcher: FileFetcher
+      parser: CRUXPortsJsonParser
+      url: https://crux.ninja/portdb/repology/
   repolinks:
     - desc: CRUX home
       url: https://crux.nu/
     - desc: CRUX port browser
-      url: https://crux.nu/portdb
-  packagelinks:
-    - desc: Port directory
-      url: 'https://crux.nu/ports/crux-3.2/{subrepo}/{name}'
-    - desc: Pkgfile
-      url: 'https://crux.nu/ports/crux-3.2/{subrepo}/{name}/Pkgfile'
-  tags: [ all, production, crux ]
-
-- name: crux_33
-  type: repository
-  desc: CRUX 3.3
-  statsgroup: CRUX
-  family: crux
-  minpackages: 1000
-  sources:
-    - name: [ core, opt, xorg, contrib ]
-      fetcher: RsyncFetcher
-      parser: CRUXParser
-      url: 'crux.nu::ports/{source}/3.3/'
-      subrepo: '{source}'
-  repolinks:
-    - desc: CRUX home
-      url: https://crux.nu/
-    - desc: CRUX port browser
-      url: https://crux.nu/portdb
-  packagelinks:
-    - desc: Port directory
-      url: 'https://crux.nu/ports/crux-3.3/{subrepo}/{name}'
-    - desc: Pkgfile
-      url: 'https://crux.nu/ports/crux-3.3/{subrepo}/{name}/Pkgfile'
-  tags: [ all, production, crux ]
-
-- name: crux_34
-  type: repository
-  desc: CRUX 3.4
-  statsgroup: CRUX
-  family: crux
-  minpackages: 1000
-  sources:
-    - name: [ core, opt, xorg, contrib ]
-      fetcher: RsyncFetcher
-      parser: CRUXParser
-      url: 'crux.nu::ports/{source}/3.4/'
-      subrepo: '{source}'
-  repolinks:
-    - desc: CRUX home
-      url: https://crux.nu/
-    - desc: CRUX port browser
-      url: https://crux.nu/portdb
-  packagelinks:
-    - desc: Port directory
-      url: 'https://crux.nu/ports/crux-3.4/{subrepo}/{name}'
-    - desc: Pkgfile
-      url: 'https://crux.nu/ports/crux-3.4/{subrepo}/{name}/Pkgfile'
-  tags: [ all, production, crux ]
-
-- name: crux_35
-  type: repository
-  desc: CRUX 3.5
-  statsgroup: CRUX
-  family: crux
-  minpackages: 1000
-  sources:
-    - name: [ core, opt, xorg, contrib ]
-      fetcher: RsyncFetcher
-      parser: CRUXParser
-      url: 'crux.nu::ports/{source}/3.5/'
-      subrepo: '{source}'
-  repolinks:
-    - desc: CRUX home
-      url: https://crux.nu/
-    - desc: CRUX port browser
-      url: https://crux.nu/portdb
-  packagelinks:
-    - desc: Port directory
-      url: 'https://crux.nu/ports/{subrepo}/3.5/{name}'
-    - desc: Pkgfile
-      url: 'https://crux.nu/ports/{subrepo}/3.5/{name}/Pkgfile'
+      url: https://crux.nu/portdb/
   tags: [ all, production, crux ]


### PR DESCRIPTION
…ther than the deprecated plaintext parser

This hopefully fixes issue #1054 and makes for a more future-proof setup. I'm new to repology so it's certainly possible this can be improved. Comments/questions welcome, of course.

With that said, I removed the 'statsgroup' item from the repo config as it appeared to only make sense in the context of multiple repositories in the same config (such as the old separation between CRUX versions). Only the current version is supported for the most part. This is also the reason for the change of name and description.

Tagging @TimB87 as well.