### PR TITLE
openwrt: un-shadow snapshot

### DIFF
--- a/repos.d/embedded/openwrt.yaml
+++ b/repos.d/embedded/openwrt.yaml
@@ -95,7 +95,6 @@
       parser: OpenWrtPackagesParser
       url: 'https://downloads.openwrt.org/snapshots/packages/x86_64/{source}/Packages.manifest'
       subrepo: '{source}'
-  shadow: true
   repolinks:
     - desc: OpenWrt home
       url: https://openwrt.org/


### PR DESCRIPTION
It pretty useful to show the package status for snapshot builds.