### PR TITLE
Rename blackbox to backbox

### DIFF
--- a/repos.d/deb/backbox.yaml
+++ b/repos.d/deb/backbox.yaml
@@ -1,11 +1,11 @@
 ###########################################################################
-# BlackBox Linux
+# BackBox Linux
 #
 # https://launchpad.net/~backbox
 ###########################################################################
-- name: blackbox_6
+- name: backbox_6
   type: repository
-  desc: BlackBox 6
+  desc: BackBox 6
   statsgroup: Debian+derivs
   family: debuntu
   color: '32638f'
@@ -17,13 +17,13 @@
       url: 'http://ppa.launchpad.net/backbox/six/ubuntu/dists/bionic/main/source/Sources.xz'
       compression: xz
   repolinks:
-    - desc: BlackBox Linux home
+    - desc: BackBox Linux home
       url: https://linux.backbox.org/
-  tags: [ all, production, blackbox ]
+  tags: [ all, production, backbox ]
 
-- name: blackbox_7
+- name: backbox_7
   type: repository
-  desc: BlackBox 7
+  desc: BackBox 7
   statsgroup: Debian+derivs
   family: debuntu
   color: '32638f'
@@ -35,6 +35,6 @@
       url: 'http://ppa.launchpad.net/backbox/seven/ubuntu/dists/focal/main/source/Sources.xz'
       compression: xz
   repolinks:
-    - desc: BlackBox Linux home
+    - desc: BackBox Linux home
       url: https://linux.backbox.org/
-  tags: [ all, production, blackbox ]
+  tags: [ all, production, backbox ]


### PR DESCRIPTION
I believe it was a typo. The distro is actually named backbox, not blackbox.

This commit renames the yaml file, and also updates all references from 'blackbox' to 'backbox'.