### PR TITLE
kiss.yaml: Point to community maintained repos

### DIFF
--- a/repos.d/kiss.yaml
+++ b/repos.d/kiss.yaml
@@ -11,7 +11,7 @@
     - name: repo
       fetcher: GitFetcher
       parser: KissGitParser
-      url: 'https://github.com/kisslinux/repo.git'
+      url: 'https://github.com/kiss-community/repo-main.git'
       maintainer_from_git: true
       depth: null
       sparse_checkout: [ '**/version', '**/sources' ]
@@ -21,10 +21,10 @@
     - desc: KISS Linux - Package System
       url: https://k1ss.org/package-system/
     - desc: Main Repositories on GitHub
-      url: https://github.com/kisslinux/repo
+      url: https://github.com/kiss-community/repo-main
   packagelinks:
     - desc: Package directory on GitHub
-      url: 'https://github.com/kisslinux/repo/tree/master/{path}'
+      url: 'https://github.com/kiss-community/repo-main/tree/master/{path}'
   tags: [ all, production, kiss ]
 
 - name: kiss_community
@@ -37,18 +37,18 @@
     - name: repo
       fetcher: GitFetcher
       parser: KissGitParser
-      url: 'https://github.com/kisslinux/community.git'
+      url: 'https://github.com/kiss-community/repo-community.git'
       maintainer_from_git: true
       depth: null
       sparse_checkout: [ '**/version', '**/sources' ]
   repolinks:
     - desc: KISS Linux home
-      url: https://getkiss.org/
+      url: https://k1ss.org/
     - desc: KISS Linux - Package System
-      url: https://getkiss.org/pages/package-system/
+      url: https://k1ss.org/package-system/
     - desc: Community Repository on GitHub
-      url: https://github.com/kisslinux/community
+      url: https://github.com/kiss-community/repo-community
   packagelinks:
     - desc: Package directory on GitHub
-      url: 'https://github.com/kisslinux/community/tree/master/{path}'
+      url: 'https://github.com/kiss-community/repo-community/tree/main/{path}'
   tags: [ all, production, kiss ]

--- a/repos.d/kiss.yaml
+++ b/repos.d/kiss.yaml
@@ -38,6 +38,7 @@
       fetcher: GitFetcher
       parser: KissGitParser
       url: 'https://github.com/kiss-community/repo-community.git'
+      branch: main
       maintainer_from_git: true
       depth: null
       sparse_checkout: [ '**/version', '**/sources' ]


### PR DESCRIPTION
Hi, the BDFL of KISS (@dylanaraps) has been gone for [~2 months](https://github.com/dylanaraps?tab=overview&from=2020-12-01&to=2020-12-31) now. In his absence, the KISS repos have been forked and are being maintained in @kiss-community until he is back. It's been quite a while, so I think it is correct now to point repology to the new repos.