### PR TITLE
Termux: update metadata url

### DIFF
--- a/repos.d/termux.yaml
+++ b/repos.d/termux.yaml
@@ -11,7 +11,7 @@
     - name: packages.json
       fetcher: FileFetcher
       parser: TermuxJsonParser
-      url: https://dl.bintray.com/termux/metadata/repology/packages.json
+      url: https://raw.githubusercontent.com/termux/repology-metadata/master/packages.json
   repolinks:
     - desc: Termux home
       url: https://termux.com/


### PR DESCRIPTION
@termux is changing the location of `packages.json` as JFrog Bintray [announced](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/) its end of service.