### PR TITLE
repos.d/bsd/freebsd: update freebsd links to cgit

### DIFF
--- a/repology/test/test_parsers.py
+++ b/repology/test/test_parsers.py
@@ -137,8 +137,8 @@ class TestParsers(unittest.TestCase):
                 'links': [
                     (LinkType.UPSTREAM_HOMEPAGE, 'http://www.vorbis.com/'),
                     (LinkType.PACKAGE_HOMEPAGE, 'https://www.freshports.org/audio/vorbis-tools'),
-                    (LinkType.PACKAGE_SOURCES, 'https://svnweb.freebsd.org/ports/head/audio/vorbis-tools/'),
-                    (LinkType.PACKAGE_RECIPE_RAW, 'https://svnweb.freebsd.org/ports/head/audio/vorbis-tools/Makefile?view=co'),
+                    (LinkType.PACKAGE_SOURCES, 'https://cgit.freebsd.org/ports/tree/audio/vorbis-tools/'),
+                    (LinkType.PACKAGE_RECIPE_RAW, 'https://cgit.freebsd.org/ports/plain/audio/vorbis-tools/Makefile'),
                     (LinkType.PACKAGE_ISSUE_TRACKER, 'https://bugs.freebsd.org/bugzilla/buglist.cgi?quicksearch=audio/vorbis-tools'),
                 ],
             }

--- a/repos.d/bsd/freebsd.yaml
+++ b/repos.d/bsd/freebsd.yaml
@@ -25,17 +25,17 @@
       url: https://www.freebsd.org/ports/
     - desc: FreshPorts - The Place For Ports
       url: https://www.freshports.org/
-    - desc: FreeBSD ports SVN repository
-      url: https://svnweb.freebsd.org/ports/head/
+    - desc: FreeBSD ports Git repository
+      url: https://cgit.freebsd.org/ports/tree/
     - desc: Package builds status
       url: https://pkg-status.freebsd.org/
   packagelinks:
     - type: PACKAGE_HOMEPAGE
       url: 'https://www.freshports.org/{srcname}'
     - type: PACKAGE_SOURCES
-      url: 'https://svnweb.freebsd.org/ports/head/{srcname}/'
+      url: 'https://cgit.freebsd.org/ports/tree/{srcname}/'
     - type: PACKAGE_RECIPE_RAW
-      url: 'https://svnweb.freebsd.org/ports/head/{srcname}/Makefile?view=co'
+      url: 'https://cgit.freebsd.org/ports/plain/{srcname}/Makefile'
     - type: PACKAGE_ISSUE_TRACKER
       url: 'https://bugs.freebsd.org/bugzilla/buglist.cgi?quicksearch={srcname}'
   tags: [ all, production, have_testdata ]


### PR DESCRIPTION
Project has recently moved to git and the new web ui cgit.freebsd.org is
replacing svnweb.freebsd.org. Update freebsd repo links accordingly.