### PR TITLE
Fix Fedora 34 URL

### DIFF
--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -338,10 +338,10 @@
   color: '294172'
   minpackages: 18000
   sources:
-    - name: development
+    - name: release
       fetcher:
         class: RepodataFetcher
-        url: https://mirror.yandex.ru/fedora/linux/development/34/Everything/source/tree/
+        url: https://mirror.yandex.ru/fedora/linux/releases/34/Everything/source/tree/
       parser:
         class: RepodataParser
       subrepo: '{source}'


### PR DESCRIPTION
Fedora 34 has been released, and the URL should reflect that.