### PR TITLE
Adding basic Docker/docker-compose deployment option 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+FROM python:3.9
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y \
+      python3-pip \
+      postgresql \
+      postgresql-contrib \
+      pkg-config \
+      wget \
+      yajl-tools \
+      libyajl-dev \
+      cmake \
+      libpq-dev
+
+WORKDIR /opt
+RUN wget https://github.com/repology/libversion/archive/refs/tags/3.0.1.tar.gz && \
+    tar -xzvf 3.0.1.tar.gz && \
+    cd libversion-3.0.1 && \
+    mkdir build && \
+    cmake . && \
+    cd build && \
+    cmake --build ../ && \
+    cd ../ && \
+    make install && \
+    ldconfig
+    
+WORKDIR /code
+COPY . /code
+RUN pip install -r requirements.txt && pip install -r requirements-dev.txt && \
+    # import rpm required, not clear which is needed
+    pip install rpm
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+version: "3.9"
+services:
+  db:
+    # Important! Do not use this in production without changing credentials
+    env_file:
+      - postgres.env
+
+    restart: always
+    build:
+      context: docker/
+      dockerfile: Dockerfile.db
+
+
+  repology:
+    entrypoint: ["tail", "-f", "/dev/null"]
+    build:
+      context: .
+      dockerfile: Dockerfile
+
+    # For development so changes to local files can be propograted with restart
+    volumes:
+      - ./:/code
+    links:
+      - db

--- a/docker/Dockerfile.db
+++ b/docker/Dockerfile.db
@@ -1,0 +1,39 @@
+FROM postgres:13.3
+
+# docker build -t repology-db .
+
+# NOTE: this is for development only! These are the development credentials
+# defined in the README.md and default configuration file. You should
+# absolutely not use this in a production setting.
+
+RUN apt-get update && apt-get install -y git \
+      build-essential \
+      postgresql-server-dev-13 \
+      wget \
+      pkg-config \
+      cmake
+
+WORKDIR /opt
+RUN wget https://github.com/repology/libversion/archive/refs/tags/3.0.1.tar.gz && \
+    tar -xzvf 3.0.1.tar.gz && \
+    cd libversion-3.0.1 && \
+    mkdir build && \
+    cmake . && \
+    cd build && \
+    cmake --build ../ && \
+    cd ../ && \
+    make install && \
+    ldconfig
+
+WORKDIR /opt
+RUN git clone https://github.com/repology/postgresql-libversion && \
+    cd postgresql-libversion && \
+    make && \
+    make install && \
+    ldconfig
+
+WORKDIR /docker-entrypoint-initdb.d
+RUN echo 'psql --username ${POSTGRES_USER} --dbname ${POSTGRES_DB} -c "CREATE EXTENSION pg_trgm"' > extension1.sh && \
+    echo 'psql --username ${POSTGRES_USER} --dbname ${POSTGRES_DB} -c "CREATE EXTENSION libversion"' > extension2.sh && \
+    chmod +x extension*.sh
+    

--- a/postgres.env
+++ b/postgres.env
@@ -1,0 +1,3 @@
+POSTGRES_DB=repology
+POSTGRES_USER=repology
+POSTGRES_PASSWORD=repology


### PR DESCRIPTION
This pull request will add a Docker / docker-compose development environment for easier development. I found this essential to start developing spack, PR #1173. Once this is integrated I will follow up with an updated PR for #1173 that integrates these changes, and the changes requested in review. I have to do this order because I need the development environment to test it locally. Thank you!

Signed-off-by: vsoch <vsoch@users.noreply.github.com>