### PR TITLE
Remove manjaro staging

### DIFF
--- a/repos.d/arch/manjaro.yaml
+++ b/repos.d/arch/manjaro.yaml
@@ -22,27 +22,6 @@
       url: https://manjaro.org/
   groups: [ all, production, manjaro ]
   
-- name: manjaro_staging
-  type: repository
-  desc: Manjaro Staging
-  statsgroup: Arch+derivs
-  family: arch
-  ruleset: [arch, manjaro]
-  color: '34be5b'
-  minpackages: 10000
-  sources:
-    - name: [ community, core, extra, multilib ]
-      fetcher:
-        class: TarFetcher
-        url: 'https://mirror.yandex.ru/mirrors/manjaro/stable-staging/{source}/x86_64/{source}.db.tar.gz'
-      parser:
-        class: ArchDBParser
-      subrepo: '{source}'
-  repolinks:
-    - desc: Manjaro Linux home
-      url: https://manjaro.org/
-  groups: [ all, production, manjaro ]
-
 - name: manjaro_testing
   type: repository
   desc: Manjaro Testing


### PR DESCRIPTION
Manjaro team is going to disolve staging branch.
For reference, see the announcement here:
https://forum.manjaro.org/t/stable-staging-update-2021-11-17-kernels-gnome-41-1-xorg-server-21-1-lxqt-1-0-nvidia-470-86-plasma-5-23-3-frameworks-5-88/90709