### PR TITLE
Re-enable nixpkgs-unstable

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -85,4 +85,4 @@
   packagelinks:
     - type: PACKAGE_RECIPE
       url: 'https://github.com/NixOS/nixpkgs/blob/master/{?posfile}#L{?posline}'
-  groups: [ all, have_testdata, nix ]
+  groups: [ all, production, have_testdata, nix ]


### PR DESCRIPTION
Can usually take up to a day for a release update to happen, so didn't notice immediately.

This was fixed in https://github.com/NixOS/nixpkgs/pull/158548

Then needed to wait for a release with the fixes https://status.nixos.org/

As mentioned in https://github.com/repology/repology-updater/issues/1222#issuecomment-1033741461, there was a successful parse 1 hour before it was disabled.