### PR TITLE
Fix link to nixpkgs-unstable

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -84,5 +84,5 @@
       url: https://github.com/NixOS/nixpkgs
   packagelinks:
     - type: PACKAGE_RECIPE
-      url: 'https://github.com/NixOS/nixpkgs/blob/master/{?posfile}#L{?posline}'
+      url: 'https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/{?posfile}#L{?posline}'
   groups: [ all, production, have_testdata, nix ]

--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -84,5 +84,5 @@
       url: https://github.com/NixOS/nixpkgs
   packagelinks:
     - type: PACKAGE_RECIPE
-      url: 'https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/{?posfile}#L{?posline}'
+      url: 'https://github.com/NixOS/nixpkgs/blob/nixos-unstable/{?posfile}#L{?posline}'
   groups: [ all, production, have_testdata, nix ]


### PR DESCRIPTION
I could be wrong but think this should point to the nixpkgs-unstable branch not master?

@jonringer 