### PR TITLE
Update termux homepage url

### DIFF
--- a/repos.d/termux.yaml
+++ b/repos.d/termux.yaml
@@ -16,7 +16,7 @@
         class: TermuxJsonParser
   repolinks:
     - desc: Termux home
-      url: https://termux.com/
+      url: https://termux.org/
     - desc: Packages repository
       url: https://github.com/termux/termux-packages
   # packagelinks produced by the parser


### PR DESCRIPTION
Both termux.com and termux.org continue to be valid, but .org is the one we have verified at github [1] and are promoting.

[1] https://github.com/termux