### PR TITLE
Update Chaotic-AUR link

### DIFF
--- a/repos.d/arch/aur.yaml
+++ b/repos.d/arch/aur.yaml
@@ -51,7 +51,7 @@
   repolinks:
     - desc: Chaotic-AUR Home
       url: https://aur.chaotic.cx
-  groups: [ all ]
+  groups: [ all, production ]
 
 - name: mpr
   type: repository

--- a/repos.d/arch/aur.yaml
+++ b/repos.d/arch/aur.yaml
@@ -50,8 +50,8 @@
       #    url: 'https://archlinux.pkgs.org/rolling/chaotic-aur-x86_64/{binname}-{rawversion}-x86_64.pkg.tar.zst.html'
   repolinks:
     - desc: Chaotic-AUR Home
-      url: https://lonewolf.pedrohlc.com/chaotic-aur/
-  groups: [ all ] # broken: garbage in info for cl-alexandria-git-r284.2c1968d-1:
+      url: https://aur.chaotic.cx
+  groups: [ all ]
 
 - name: mpr
   type: repository


### PR DESCRIPTION
Hello! 
I updated the Chaotic-AUR website link and hope that we can have it back on Repology. We no longer build the problematic package.

Cheers!