### PR TITLE
Remove outdated nixpkgs repositories

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -34,7 +34,6 @@
   groups: [ all, production, nix ]
 {% endmacro %}
 
-{{ nix('21.11', minpackages=70000, valid_till='2022-06-30') }}
 {{ nix('22.05', minpackages=70000, valid_till='2022-12-31') }}
 
 - name: nix_unstable

--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -1,35 +1,6 @@
 ###########################################################################
 # NixOS packages
 ###########################################################################
-- name: nix_stable  # XXX: remove in 2022
-  type: repository
-  desc: nixpkgs stable 21.05
-  statsgroup: nix
-  family: nix
-  ruleset: [nix,nix_old_node_naming]
-  color: '7eb2dd'
-  minpackages: 60000
-  valid_till: 2021-12-31
-  default_maintainer: fallback-mnt-nix@repology
-  sources:
-    - name: packages.json
-      fetcher:
-        class: FileFetcher
-        url: https://channels.nixos.org/nixos-21.05/packages.json.br
-      parser:
-        class: NixJsonParser
-  repolinks:
-    - desc: NixOS home
-      url: https://nixos.org
-    - desc: NixOS packages
-      url: https://search.nixos.org/packages
-    - desc: GitHub repository
-      url: https://github.com/NixOS/nixpkgs
-  packagelinks:
-    - type: PACKAGE_RECIPE
-      url: 'https://github.com/NixOS/nixpkgs/blob/release-21.05/{?posfile}#L{?posline}'
-  groups: [ all, production, nix ]
-
 {% macro nix(branch, minpackages, valid_till) %}
 - name: nix_stable_{{branch|replace('.', '_')}}
   type: repository


### PR DESCRIPTION
- nixpkgs 21.05 has reached EOL at the end of the year 2021, and no longer receives updates.
- nixpkgs 21.11 has reached EOL on June 30, 2022.


<a href="https://status.nixos.org/"><img width="1044" alt="image" src="https://user-images.githubusercontent.com/65531/181420653-407c1878-8928-48cb-b813-ce4c28452e45.png"></a>
