### PR TITLE
Add all Adelie Linux architectures

### DIFF
--- a/repos.d/adelie.yaml
+++ b/repos.d/adelie.yaml
@@ -10,14 +10,20 @@
   minpackages: 900
   default_maintainer: fallback-mnt-adelie@repology
   sources:
-    # XXX: add all arches?
-    - name: [ system, user ]
+    - name: [ system/aarch64, system/armv7, system/pmmx, system/ppc, system/ppc64, system/x86_64 ]
       fetcher:
         class: TarFetcher
-        url: 'https://distfiles.adelielinux.org/adelie/current/{source}/ppc64/APKINDEX.tar.gz'
+        url: 'https://distfiles.adelielinux.org/adelie/current/{source}/APKINDEX.tar.gz'
       parser:
         class: ApkIndexParser
-      subrepo: '{source}'
+      subrepo: system
+    - name: [ user/aarch64, user/armv7, user/pmmx, user/ppc, user/ppc64, user/x86_64 ]
+      fetcher:
+        class: TarFetcher
+        url: 'https://distfiles.adelielinux.org/adelie/current/{source}/APKINDEX.tar.gz'
+      parser:
+        class: ApkIndexParser
+      subrepo: user
   repolinks:
     - desc: Adélie Linux home
       url: https://adelielinux.org/


### PR DESCRIPTION
As all packages are not necessarily in all architectures, this fetches the package index for each supported architecture and adds the data to the corresponding subrepo. This addresses a comment that was previously present in the yaml file.

I apologize for anything I did wrong or misinterpreted, and would greatly appreciate any suggestions for improvement.