### PR TITLE
Add Fedora 37

### DIFF
--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -90,4 +90,5 @@
 {{ fedora(34, minpackages=24000, valid_till='2022-05-17') }}
 {{ fedora(35, minpackages=24000, valid_till='2022-11-30') }}
 {{ fedora(36, minpackages=21000, valid_till='2023-05-24') }}
+{{ fedora(37, minpackages=21000) }}
 {{ fedora('rawhide', minpackages=21000, development=True) }}


### PR DESCRIPTION
Fedora 37 is in final beta and many people are running it, so it's
useful to have it scraped.