### PR TITLE
Fix EPEL 6 package links

### DIFF
--- a/repos.d/rpm/epel.yaml
+++ b/repos.d/rpm/epel.yaml
@@ -21,16 +21,13 @@
   repolinks:
     - desc: EPEL wiki page
       url: https://fedoraproject.org/wiki/EPEL
-  # 99.9% links broken, no such branch epel6
-  #packagelinks:
-  #  # this pattern falls back to default branch, but it's still useless
-  #  - type: PACKAGE_SOURCES
-  #    url: 'https://src.fedoraproject.org/rpms/{srcname}/tree/epel6'
-  #  # these patterns are completely broken
-  #  - type: PACKAGE_RECIPE
-  #    url: 'https://src.fedoraproject.org/rpms/{srcname}/blob/epel6/f/{srcname}.spec'
-  #  - type: PACKAGE_RECIPE_RAW
-  #    url: 'https://src.fedoraproject.org/rpms/{srcname}/raw/epel6/f/{srcname}.spec'
+  packagelinks:
+    - type: PACKAGE_SOURCES
+      url: 'https://src.fedoraproject.org/rpms/{srcname}/tree/el{{version}}'
+    - type: PACKAGE_RECIPE
+      url: 'https://src.fedoraproject.org/rpms/{srcname}/blob/el{{version}}/f/{srcname}.spec'
+    - type: PACKAGE_RECIPE_RAW
+      url: 'https://src.fedoraproject.org/rpms/{srcname}/raw/el{{version}}/f/{srcname}.spec'
   groups: [ all, production, epel ]
 
 {% macro epel(version, minpackages, subdir) %}


### PR DESCRIPTION
Before EPEL 7, the branches were named `el<version>` instead of `epel<version>`.