### PR TITLE
Reflect ownership transfer of Ravenports

### DIFF
--- a/repos.d/bsd/ravenports.yaml
+++ b/repos.d/bsd/ravenports.yaml
@@ -12,24 +12,24 @@
     - name: repology.json
       fetcher:
         class: FileFetcher
-        url: https://raw.githubusercontent.com/jrmarino/Ravenports/master/Mk/Misc/repology.json
+        url: https://raw.githubusercontent.com/Ravenports/Ravenports/master/Mk/Misc/repology.json
         allow_zero_size: false
       parser:
         class: RavenportsJsonParser
   repolinks:
     - desc: Ravenports Catalog
-      url: http://ravenports.ironwolf.systems/catalog/
+      url: http://www.ravenports.com/catalog/
     - desc: Ravenports GitHub repository
-      url: https://github.com/jrmarino/Ravenports
+      url: https://github.com/Ravenports/Ravenports
   packagelinks:
     - type: PACKAGE_HOMEPAGE
       url: 'http://ravenports.ironwolf.systems/catalog/bucket_{bucket}/{name}/{variant}/'
     - type: PACKAGE_SOURCES
-      url: 'https://github.com/jrmarino/ravensource/tree/master/bucket_{bucket}/{name}'
+      url: 'https://github.com/Ravenports/ravensource/tree/master/bucket_{bucket}/{name}'
     - type: PACKAGE_RECIPE
-      url: 'https://github.com/jrmarino/Ravenports/blob/master/bucket_{bucket}/{name}'
+      url: 'https://github.com/Ravenports/Ravenports/blob/master/bucket_{bucket}/{name}'
     - type: PACKAGE_RECIPE_RAW
-      url: 'https://raw.githubusercontent.com/jrmarino/Ravenports/master/bucket_{bucket}/{name}'
+      url: 'https://raw.githubusercontent.com/Ravenports/Ravenports/master/bucket_{bucket}/{name}'
     - type: PACKAGE_BUILD_LOG_RAW  # dragonflybsd specific logs
       url: 'https://loki.dragonflybsd.org/raven/logs/{name}___{variant}.log'
   groups: [ all, production ]


### PR DESCRIPTION
John Marino transferred ownership of several repositories supporting Ravenports to the newly created Ravenports organization.

The catalog URL was also updated to the www.ravenports.com domain.