### PR TITLE
fix repo url for void linux

### DIFF
--- a/repos.d/void.yaml
+++ b/repos.d/void.yaml
@@ -17,7 +17,7 @@
     - name: [ x86_64, nonfree/x86_64 ]
       fetcher:
         class: TarFetcher
-        url: 'https://alpha.de.repo.voidlinux.org/current/{source}-repodata'
+        url: 'https://repo-default.voidlinux.org/current/{source}-repodata'
       parser:
         class: VoidLinuxPlistParser
       subrepo: '{source}'


### PR DESCRIPTION
The old url still works, but this will be the one to use going forward