### PR TITLE
Packages that don't have urls don't have versions

### DIFF
--- a/repology/parsers/parsers/glaucus.py
+++ b/repology/parsers/parsers/glaucus.py
@@ -46,9 +46,6 @@ class GlaucusGitParser(Parser):
                 if package_subdir != pkgdata['nom']:
                     raise RuntimeError(f'package subdir "{package_subdir}" is expected to be equal to package name "{pkgdata["nom"]}"')
 
-                if 'ver' not in pkgdata:
-                    pkg.log('package without version, skipping', Logger.ERROR)
-                    continue
                 if 'url' not in pkgdata:
                     pkg.log('package without url, assuming virtual package and skipping', Logger.ERROR)
                     continue


### PR DESCRIPTION
By skipping packages that don't have `url`s we're also skipping packages that don't have a version number (a package that has a `url` must have a version number and a checksum, but the latter is not true, meaning that checking for `url` only should suffice to determine virtual packages).

This should simplify things by a bit.