### PR TITLE
nixos: Add 22.11 release

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -36,6 +36,7 @@
 
 {{ nix('21.11', minpackages=70000, valid_till='2022-06-30') }}
 {{ nix('22.05', minpackages=70000, valid_till='2022-12-31') }}
+{{ nix('22.11', minpackages=70000, valid_till='2023-06-30') }}
 
 - name: nix_unstable
   type: repository


### PR DESCRIPTION
- NixOS 22.11 has been branched and will be released on 2022-11-30.
- NixOS 22.11 has been EOL for 5 months.