### PR TITLE
Fix typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/newrepo.md
+++ b/.github/ISSUE_TEMPLATE/newrepo.md
@@ -52,7 +52,7 @@ Other useful link types include package page, package related issues, build stat
 
 **Additional details**
 <!--
-- More links, such as distibution/repository homepage or GitHub organization
+- More links, such as distribution/repository homepage or GitHub organization
 - Brand color, if any
 - EoL date, if applicable
 - Contact in case of fetch failures or data problems

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Next, run the update process:
 ```
 
 Expect it to take several hours the first time, subsequent updates
-will be faster. You can use the same commant to updated. Brief
+will be faster. You can use the same command to updated. Brief
 explanation of options used here:
 
   - `--fetch` tells the utility to fetch raw repository data

--- a/repology-update.py
+++ b/repology-update.py
@@ -136,7 +136,7 @@ def process_repositories(env: Environment) -> None:
         elif env.get_options().fetch:
             env.get_main_logger().log('fetching {}'.format(reponame))
 
-            # make sure hash is reset untill it's known that the update did not untroduce any changes
+            # make sure hash is reset until it's known that the update did not untroduce any changes
             old_hash = database.get_repository_ruleset_hash(reponame)
             database.update_repository_ruleset_hash(reponame, None)
             database.commit()

--- a/repology/parsers/parsers/freshcode.py
+++ b/repology/parsers/parsers/freshcode.py
@@ -42,7 +42,7 @@ class FreshcodeParser(Parser):
                 pkg.set_version(entry['version'])
 
                 pkg.add_homepages(entry.get('homepage'))
-                pkg.set_summary(entry.get('summary'))  # cound use `or entry.get('description'))`, but it's long multiline
+                pkg.set_summary(entry.get('summary'))  # could use `or entry.get('description'))`, but it's long multiline
                 #pkg.add_maintainers(entry.get('submitter') + '@freshcode')  # unfiltered garbage
                 #pkg.add_downloads(entry.get('download'))  # ignore for now, may contain download page urls instead of file urls
                 pkg.add_licenses(entry.get('license'))

--- a/repology/parsers/parsers/winget.py
+++ b/repology/parsers/parsers/winget.py
@@ -74,7 +74,7 @@ class WingetGitParser(Parser):
                 pkg.add_name(pkgdata['PackageIdentifier'].split('.', 1)[-1], NameType.WINGET_ID_NAME)
                 pkg.add_name(pkgdata['PackageName'], NameType.WINGET_NAME)
                 pkg.add_name(pkgloc.relevant_path, NameType.WINGET_PATH)
-                # Moniker field is optional and mosty useless
+                # Moniker field is optional and mostly useless
 
                 version = pkgdata['PackageVersion']
                 if isinstance(version, float):

--- a/repos.d/rpm/opensuse/repos.yaml
+++ b/repos.d/rpm/opensuse/repos.yaml
@@ -5,7 +5,7 @@
 # XXX: packagelinks problems:
 #
 # - We don't have information on than a package is produced by multibuild.
-#   For intance, for mumps-mvapich2 package we generate spec link
+#   For instance, for mumps-mvapich2 package we generate spec link
 #
 #     https://build.opensuse.org/package/view_file/science/mumps-mvapich2/mumps-mvapich2.spec
 #

--- a/sql.d/update/update_projects_has_related.sql
+++ b/sql.d/update/update_projects_has_related.sql
@@ -16,7 +16,7 @@
 -- along with repology.  If not, see <http://www.gnu.org/licenses/>.
 
 -- XXX: AS METARIALIZED here yields a bit better performance;
--- may add it when we swith to Pg12 everywhere and require it
+-- may add it when we switch to Pg12 everywhere and require it
 WITH metapackages_with_related AS (
 	SELECT DISTINCT metapackage_id
 	FROM url_relations

--- a/tests/transformer/test_matchers.py
+++ b/tests/transformer/test_matchers.py
@@ -32,7 +32,7 @@ def test_name():
 
 def test_name_multi():
     # XXX: may not in fact cover multi-name branch of `name' matcher
-    # bacause rules with multiple names are split to single-name rules
+    # because rules with multiple names are split to single-name rules
     # in Ruleset as an optimization
     check_transformer(
         '[ { name: [p1,p2], setname: bar } ]',


### PR DESCRIPTION
Found via `codespell -S testdata,*.proto -L
crate,siduction,sting,rougly,pase`