### PR TITLE
Add openports.pl links for OpenBSD packages

### DIFF
--- a/repos.d/bsd/openbsd.yaml
+++ b/repos.d/bsd/openbsd.yaml
@@ -23,11 +23,15 @@
   repolinks:
     - desc: 'OpenBSD FAQ: Packages and Ports'
       url: https://www.openbsd.org/faq/faq15.html
+    - desc: openports.pl
+      url: https://openports.pl/
     - desc: openports.se
       url: http://openports.se/
     - desc: OpenBSD ports CVS repository
       url: http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/
   packagelinks:
+    - type: PACKAGE_HOMEPAGE
+      url: 'https://openports.pl/path/{srcname}'
     - type: PACKAGE_HOMEPAGE
       url: 'http://openports.se/{srcname}'
     - type: PACKAGE_SOURCES


### PR DESCRIPTION
This adds links to openports.pl to OpenBSD packages. Links to openports.se are retained. See Issue #1299.