### PR TITLE
Fix PACKAGE_HOMEPAGE for guix

### DIFF
--- a/repos.d/guix.yaml
+++ b/repos.d/guix.yaml
@@ -23,7 +23,7 @@
       url: https://git.savannah.gnu.org/cgit/guix.git/
   packagelinks:
     - type: PACKAGE_HOMEPAGE
-      url: 'https://guix.gnu.org/packages/{srcname}-{rawversion}/'
+      url:  'https://packages.guix.gnu.org/packages/{srcname}/{rawversion}/'
     - type: PACKAGE_RECIPE
       url: 'https://git.savannah.gnu.org/cgit/guix.git/tree/{loc_path}#n{loc_line|dec}'
   groups: [ all, production ]


### PR DESCRIPTION
E.g. <https://guix.gnu.org/packages/gap-4.11.1> now appears to be <https://packages.guix.gnu.org/packages/gap/4.11.1>