### PR TITLE
nixpkgs: extract GitHub maintainers

### DIFF
--- a/repology/parsers/parsers/nix.py
+++ b/repology/parsers/parsers/nix.py
@@ -37,9 +37,8 @@ def extract_nix_maintainers(items: Iterable[str | dict[str, str]]) -> Iterable[s
         elif isinstance(item, dict):
             if 'email' in item:
                 yield item['email'].lower()
-            # do we need these?
-            #if 'github' in item:
-            #    yield item['github'].lower() + '@github'
+            if 'github' in item:
+                yield item['github'].lower() + '@github'
 
 
 def extract_nix_licenses(whatever: Any) -> list[str]:


### PR DESCRIPTION
A recent change (https://github.com/NixOS/nixpkgs/pull/209165) removed `noreply.github.com` email addresses from the maintainer list, which means that maintainers using only a GitHub account are not indexed by repology any more, so we now need to extract GitHub accounts as well.

I'm not sure if having multiple "handles" for the same maintainer is okay. If it isn't, replace `if` with `elif`.