### PR TITLE
Update yiffOS package URLs

### DIFF
--- a/repos.d/yiffos.yaml
+++ b/repos.d/yiffos.yaml
@@ -19,6 +19,8 @@
     - desc: yiffOS home
       url: https://yiffos.gay/
   packagelinks:
+    - type: PACKAGE_HOMEPAGE
+      url: 'https://packages.yiffos.gay/{srcname}'
     - type: PACKAGE_SOURCES
       url: 'https://git.yiffos.gay/Packaging/packages/src/branch/knot/{srcname}'
     - type: PACKAGE_RECIPE

--- a/repos.d/yiffos.yaml
+++ b/repos.d/yiffos.yaml
@@ -11,7 +11,7 @@
     - name: packages
       fetcher:
         class: GitFetcher
-        url: https://gitlab.com/yiffos/packaging/packages.git
+        url: https://git.yiffos.gay/Packaging/packages.git
         branch: knot
       parser:
         class: YiffOSJsonParser
@@ -20,9 +20,9 @@
       url: https://yiffos.gay/
   packagelinks:
     - type: PACKAGE_SOURCES
-      url: 'https://gitlab.com/yiffos/packaging/packages/-/tree/knot/{srcname}'
+      url: 'https://git.yiffos.gay/Packaging/packages/src/branch/knot/{srcname}'
     - type: PACKAGE_RECIPE
-      url: 'https://gitlab.com/yiffos/packaging/packages/-/blob/knot/{srcname}/PKGSCRIPT'
+      url: 'https://git.yiffos.gay/Packaging/packages/src/branch/knot/{srcname}/PKGSCRIPT'
     - type: PACKAGE_RECIPE_RAW
-      url: 'https://gitlab.com/yiffos/packaging/packages/-/raw/knot/{srcname}/PKGSCRIPT'
+      url: 'https://git.yiffos.gay/Packaging/packages/raw/branch/knot/{srcname}/PKGSCRIPT'
   groups: [ all, production, yiffos ]


### PR DESCRIPTION
yiffOS recently has switched Git servers to a [self-hosted one](https://git.yiffos.gay) instead of GitLab, this PR modifies the URLs in `packagelinks` to reflect the migration. 

Also `PACKAGE_HOMEPAGE` has been added as auto-generated package pages are [available](https://packages.yiffos.gay) but this can be split into another PR if requested.