### PR TITLE
Map Nix attribute path to srcname

### DIFF
--- a/repology/packagemaker/names.py
+++ b/repology/packagemaker/names.py
@@ -478,7 +478,7 @@ _MAPPINGS = [
     ),
     # Nix
     _NameMapping(
-        name=NameType.NIX_PNAME,  # it's unknown which is src and bin names for nix
+        srcname=NameType.NIX_ATTRIBUTE_PATH,
         trackname=NameType.NIX_ATTRIBUTE_PATH,
         visiblename=NameType.NIX_PNAME,
         projectname_seed=NameType.NIX_PNAME,


### PR DESCRIPTION
As hypothesized in repology/repology-webapp#218.