### PR TITLE
Enable Fedora 38 (Beta)

### DIFF
--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -101,5 +101,5 @@
 {{ fedora(35, minpackages=24000, valid_till='2022-11-15', archived=True) }}
 {{ fedora(36, minpackages=24000, valid_till='2023-05-16') }}
 {{ fedora(37, minpackages=21000, valid_till='2023-11-14') }}
-{# fedora(38, minpackages=21000, valid_till='2024-05-14', development=True) #}
+{{ fedora(38, minpackages=21000, valid_till='2024-05-14', development=True) }}
 {{ fedora('rawhide', minpackages=21000, development=True) }}


### PR DESCRIPTION
Fedora 38 is Beta, final release is targeted for in about a month.