### PR TITLE
Re-enable Solus with new CDN repository

### DIFF
--- a/repos.d/solus.yaml
+++ b/repos.d/solus.yaml
@@ -11,13 +11,13 @@
     - name: eopkg-index.xml
       fetcher:
         class: FileFetcher
-        url: https://packages.getsol.us/unstable/eopkg-index.xml.xz
+        url: https://cdn.getsol.us/repo/unstable/eopkg-index.xml.xz
         compression: xz
       parser:
         class: SolusIndexParser
   repolinks:
     - desc: Solus home
-      url: https://getsol.us/home/
+      url: https://getsol.us/
   packagelinks:
     - type: PACKAGE_SOURCES
       url: 'https://dev.getsol.us/source/{srcname}/'
@@ -25,4 +25,4 @@
       url: 'https://dev.getsol.us/source/{srcname}/browse/master/package.yml'
     - type: PACKAGE_RECIPE_RAW
       url: 'https://dev.getsol.us/source/{srcname}/browse/master/package.yml?view=raw'
-  groups: [ all ]  # fetch problem
+  groups: [ all, production ]


### PR DESCRIPTION
Solus has re-activated and updated its infrastructure after the recent outage. There is now a fast CDN repository available.

Sources:
- https://discuss.getsol.us/d/9180-want-a-cdn-powered-repo-check-these-instructions
- https://getsol.us/2023/04/18/a-new-voyage/

This PR reactivates the repo, updates it to use the CDN repository and corrects the homepage link to adapt to recent changes.