### PR TITLE
Update Solus recipe repo information to new GitHub monorepo

### DIFF
--- a/repology/linkformatter.py
+++ b/repology/linkformatter.py
@@ -28,6 +28,7 @@ _FILTERS: dict[str, Callable[[str], str]] = {
     'lowercase': lambda x: x.lower(),
     'first_letter': lambda x: x.lower()[0],
     'lib_or_first_letter': lambda x: x.lower()[:4] if x.lower().startswith('lib') else x.lower()[0],
+    'py_or_first_letter': lambda x: x.lower()[:2] if x.lower().startswith('py') else x.lower()[0],
     'strip_dmo': lambda x: x[:-4] if x.endswith('-dmo') else x,
     'basename': lambda x: x.rsplit('/', 1)[-1],
     'dirname': lambda x: x.rsplit('/', 1)[0],

--- a/repos.d/solus.yaml
+++ b/repos.d/solus.yaml
@@ -21,9 +21,9 @@
       url: https://getsol.us/
   packagelinks:
     - type: PACKAGE_SOURCES
-      url: 'https://github.com/getsolus/packages/tree/main/packages/{srcname|firstletter}/{srcname}/'
+      url: 'https://github.com/getsolus/packages/tree/main/packages/{srcname|py_or_first_letter}/{srcname}/'
     - type: PACKAGE_RECIPE
-      url: 'https://github.com/getsolus/packages/blob/main/packages/{srcname|firstletter}/{srcname}/package.yml'
+      url: 'https://github.com/getsolus/packages/blob/main/packages/{srcname|py_or_first_letter}/{srcname}/package.yml'
     - type: PACKAGE_RECIPE_RAW
-      url: 'https://raw.githubusercontent.com/getsolus/packages/main/packages/{srcname|firstletter}/{srcname}/package.yml'
+      url: 'https://raw.githubusercontent.com/getsolus/packages/main/packages/{srcname|py_or_first_letter}/{srcname}/package.yml'
   groups: [ all, production ]

--- a/repos.d/solus.yaml
+++ b/repos.d/solus.yaml
@@ -17,13 +17,13 @@
       parser:
         class: SolusIndexParser
   repolinks:
-    - desc: Solus home
+    - desc: Solus Home
       url: https://getsol.us/
   packagelinks:
     - type: PACKAGE_SOURCES
-      url: 'https://dev.getsol.us/source/{srcname}/'
+      url: 'https://github.com/getsolus/packages/tree/main/packages/{srcname|firstletter}/{srcname}/'
     - type: PACKAGE_RECIPE
-      url: 'https://dev.getsol.us/source/{srcname}/browse/master/package.yml'
+      url: 'https://github.com/getsolus/packages/blob/main/packages/{srcname|firstletter}/{srcname}/package.yml'
     - type: PACKAGE_RECIPE_RAW
-      url: 'https://dev.getsol.us/source/{srcname}/browse/master/package.yml?view=raw'
+      url: 'https://raw.githubusercontent.com/getsolus/packages/main/packages/{srcname|firstletter}/{srcname}/package.yml'
   groups: [ all, production ]


### PR DESCRIPTION
Solus has changed their package recipe repo from a self-hosted phabricator instance with split package repositories to a GitHub monorepo.

WIP Note: There is a special case for packages starting with "py" which is not considered in this initial PR draft. These have their own folder in the repo. I would need something like a `'pyorfirstletter': lambda x: x.lower()[:2] if x.lower().startswith('py') else x.lower()[0]` filter, but I'm unsure whether I should add that directly to the filter section of `repology/linkformatter.py` or somewhere else entirely. Input welcomed!