### PR TITLE
Enable backports repository for Debian Bookworm

### DIFF
--- a/repos.d/deb/debian.yaml
+++ b/repos.d/deb/debian.yaml
@@ -124,7 +124,7 @@
 # list of repos and backports https://packages.debian.org/stable/
 {{ debian(10, 'buster', minpackages=28000, valid_till='2024-06-30') }}
 {{ debian(11, 'bullseye', minpackages=30000, valid_till='2026-06-30') }}
-{{ debian(12, 'bookworm', minpackages=30000, valid_till='2028-06-30', backports=False) }}
+{{ debian(12, 'bookworm', minpackages=30000, valid_till='2028-06-30') }}
 {{ debian(13, 'trixie', minpackages=30000, packages_page=False, backports=False) }}
 
 # Rolling


### PR DESCRIPTION
Backports repository for Bookworm is now open as we can see here: https://backports.debian.org/bookworm-backports/overview/