### PR TITLE
refactor: IBM i recipe

### DIFF
--- a/repos.d/rpm/ibmi.yaml
+++ b/repos.d/rpm/ibmi.yaml
@@ -11,10 +11,13 @@
     - name: main
       fetcher:
         class: RepodataFetcher
-        url: 'https://public.dhe.ibm.com/software/ibmi/products/pase/rpms/repo/'
+        url: 'https://public.dhe.ibm.com/software/ibmi/products/pase/rpms/repo-base-7.3/'
       parser:
         class: RepodataParser
   repolinks:
     - desc: IBM i Open Source
-      url: 'https://bitbucket.org/ibmi/opensource/src/master/'
+      url: 'https://ibmi-oss-docs.readthedocs.io/en/latest/README.html'
+  packagelinks:
+    - type: PACKAGE_RECIPE_RAW
+      url: https://public.dhe.ibm.com/software/ibmi/products/pase/rpms/repo-base-7.3/specs/{srcname}-{rawversion|strip_nevra_epoch}.spec
   groups: [ all, production, rpm ]


### PR DESCRIPTION
- Updated sources url
- Added link to spec files
- Updated repo link url

We now have our recipes directly browse-able.

See: https://public.dhe.ibm.com/software/ibmi/products/pase/rpms/repo-base-7.3/specs/

For the `packagelinks` section I followed the `aixtoolbox` example

https://github.com/repology/repology-updater/blob/7f00fb14fd5d5a4699eb95caff10d5fcd15e3caa/repos.d/rpm/aixtoolbox.yaml#L26-L29

As we both ship our specs in a similar manner.

@AMDmi3

Is there documentation to better understand the available config options for the yaml files?
Also these changes haven't been tested yet. Is it possible to the test the changes locally?

Part of https://github.com/repology/repology-updater/issues/1321

Fixes https://github.com/repology/repology-updater/issues/1360

CC

@ThePrez
@kadler