### PR TITLE
nixos: Add NixOS 23.11

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -38,6 +38,7 @@
 {{ nix('22.05', minpackages=75000, valid_till='2022-12-31') }}
 {{ nix('22.11', minpackages=85000, valid_till='2023-06-30') }}
 {{ nix('23.05', minpackages=90000, valid_till='2023-12-31') }}
+{{ nix('23.11', minpackages=90000, valid_till='2024-06-30') }}
 
 - name: nix_unstable
   type: repository


### PR DESCRIPTION
This adds the latest release of NixOS, 23.11 (Tapir), which was released on 2023-11-29.