### PR TITLE
ConanCenter: Parse conanfile.py attributes, ignore cci. versions

### DIFF
--- a/repos.d/conan.yaml
+++ b/repos.d/conan.yaml
@@ -12,7 +12,7 @@
       fetcher:
         class: GitFetcher
         url: https://github.com/conan-io/conan-center-index.git
-        sparse_checkout: [ 'recipes/**/config.yml', 'recipes/**/conandata.yml' ]
+        sparse_checkout: [ 'recipes/**/config.yml', 'recipes/**/conandata.yml', 'recipes/**/conanfile.py' ]
       parser:
         class: ConanGitParser
   repolinks:


### PR DESCRIPTION
Extracts additional useful attributes from `conanfile.py` files using Python's `ast` module. Only loads simple literal values, no code is executed or evaluated.

Assigns the extracted attributes:
* description -> summary,
* homepage -> upstream_homepage,
* license -> licenses,
* topics -> categories (currently disabled since only the first topic would get loaded to the DB),
* package_type as an extra field (the "library" and "application" distinction might be useful).

Also added a rule to mark versions starting with `cci.` as "noscheme" as [ConanCenter uses these for snapshot versions](https://github.com/conan-io/conan-center-index/blob/66ef93e932c2bee07af648557f08777b8d622dd1/docs/adding_packages/conanfile_attributes.md#conancenter-specific-releases-format). I hope that's the correct label.

I tested it locally with
```
./repology-update.py --initdb
./repology-update.py --fetch --fetch --parse --database --postupdate conancenter
```
and confirmed that everything is working as expected. All recipes were parsed without issues.