### PR TITLE
Add non-free-firmware for Kali

### DIFF
--- a/repos.d/deb/kali.yaml
+++ b/repos.d/deb/kali.yaml
@@ -13,7 +13,7 @@
   color: '32638f'
   minpackages: 27000
   sources:
-    - name: [ contrib, main, non-free ]
+    - name: [ contrib, main, non-free, non-free-firmware ]
       fetcher:
         class: FileFetcher
         url: 'https://http.kali.org/kali/dists/kali-rolling/{source}/source/Sources.gz'
@@ -37,7 +37,7 @@
   color: '32638f'
   minpackages: 50
   sources:
-    - name: [ contrib, main, non-free ]
+    - name: [ contrib, main, non-free, non-free-firmware ]
       fetcher:
         class: FileFetcher
         url: 'https://http.kali.org/kali/dists/kali-bleeding-edge/{source}/source/Sources.gz'


### PR DESCRIPTION
References:
- https://www.kali.org/blog/non-free-firmware-transition/
- http://http.kali.org/dists/kali-rolling/non-free-firmware/