### PR TITLE
Remove development tag from fedora 39

### DIFF
--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -102,6 +102,6 @@
 {{ fedora(36, minpackages=24000, valid_till='2023-05-16', archived=True) }}
 {{ fedora(37, minpackages=21000, valid_till='2023-11-14') }}
 {{ fedora(38, minpackages=21000, valid_till='2024-05-14') }}
-{{ fedora(39, minpackages=21000, valid_till='2024-11-12', development=True) }}
+{{ fedora(39, minpackages=21000, valid_till='2024-11-12') }}
 {# fedora(40, minpackages=21000, valid_till='2025-05-13', development=True) #}
 {{ fedora('rawhide', minpackages=21000, development=True) }}


### PR DESCRIPTION
It's not in development anymore. :)

Signed-off-by: Phil Dibowitz <phil@ipom.com>
