### PR TITLE
sagemath: Update for Sage 10.4.beta3

### DIFF
--- a/repology/parsers/parsers/sagemath.py
+++ b/repology/parsers/parsers/sagemath.py
@@ -51,7 +51,8 @@ class SageMathParser(Parser):
                 pkg.add_name(os.path.basename(pkgpath_rel), NameType.SAGEMATH_NAME)
 
                 projectname = os.path.basename(pkgpath_rel)
-                if os.path.exists(os.path.join(pkgpath_abs, 'install-requires.txt')):
+                if os.path.exists(os.path.join(pkgpath_abs, 'install-requires.txt')) or os.path.exists(os.path.join(pkgpath_abs, 'version_requirements.txt')):
+                    # version_requirements.txt has replaced install-requires.txt in Sage 10.4.beta3
                     projectname = 'python:' + projectname
 
                 pkg.add_name(projectname, NameType.SAGEMATH_PROJECT_NAME)


### PR DESCRIPTION
A change to the format of the package layout was merged into Sage 10.4.beta3. 
As a result, Python packages are no longer recognized by repology (some appear as "-unclassified", others appear without the "python:" prefix):
https://repology.org/projects/?search=&maintainer=&category=&inrepo=sagemath_develop&notinrepo=&repos=&families=&repos_newest=&families_newest=&outdated=on

Here is the simple fix.
