### PR TITLE
ubuntu: Drop 23.04

### DIFF
--- a/repos.d/deb/ubuntu.yaml
+++ b/repos.d/deb/ubuntu.yaml
@@ -125,6 +125,5 @@
 {{ ubuntu('18', '04', 'bionic',  minpackages=29000, valid_till='2023-05-31', packages=false) }}
 {{ ubuntu('20', '04', 'focal',   minpackages=29000, valid_till='2025-05-29') }}
 {{ ubuntu('22', '04', 'jammy',   minpackages=32000, valid_till='2027-06-01') }}
-{{ ubuntu('23', '04', 'lunar',   minpackages=33000, valid_till='2024-01-25') }}
 {{ ubuntu('23', '10', 'mantic',  minpackages=33000, valid_till='2024-07-11') }}
 {{ ubuntu('24', '04', 'noble',   minpackages=33000, valid_till='2029-05-31', backports=false, proposed=true) }}


### PR DESCRIPTION
It reached End of Life in January

https://wiki.ubuntu.com/Releases