### PR TITLE
Add alpine 3.20

### DIFF
--- a/repos.d/alpine/alpine.yaml
+++ b/repos.d/alpine/alpine.yaml
@@ -74,4 +74,5 @@
 {{ alpine('3.17', minpackages=16000, valid_till='2024-11-22') }}
 {{ alpine('3.18', minpackages=16000, valid_till='2025-05-09') }}
 {{ alpine('3.19', minpackages=16000, valid_till='2025-11-01') }}
-{{ alpine('edge', minpackages=20000, subrepos=['community', 'main', 'testing']) }}
+{{ alpine('3.20', minpackages=23000, valid_till='2026-04-01') }}
+{{ alpine('edge', minpackages=23000, subrepos=['community', 'main', 'testing']) }}


### PR DESCRIPTION
## Summary

Alpine [released 3.20.0](https://www.alpinelinux.org/posts/Alpine-3.20.0-released.html) on 2024-05-22.
The EOL is 2026-04-01.

This patch adds 3.20 support.

## Additional

The minimum number of packages for 3.20 and edge has been updated to 23000.