### PR TITLE
Added MSVSphere Distribution, RHEL clone like AlmaLinux and Rocky

### DIFF
--- a/repos.d/rpm/centos.yaml
+++ b/repos.d/rpm/centos.yaml
@@ -321,4 +321,4 @@
 # See https://access.redhat.com/support/policy/updates/errata for EOL date (because it's a RHEL clone)
 # Release 8 coming soon
 #{{ msvsphere(8, minpackages=2500, valid_till='2029-05-31', subrepos=['AppStream','BaseOS','HighAvailability','NFV','PowerTools','RT','ResilientStorage','Extras']) }}
-{{ msvsphere(9, minpackages=2000, valid_till='2032-05-31', subrepos=['AppStream','BaseOS','CRB','HighAvailability','NFV','RT','ResilientStorage','Extras', 'LibreOffice']) }}
+{{ msvsphere(9, minpackages=2000, valid_till='2032-05-31', subrepos=['AppStream','BaseOS','CRB','HighAvailability','NFV','RT','ResilientStorage']) }}

--- a/repos.d/rpm/centos.yaml
+++ b/repos.d/rpm/centos.yaml
@@ -278,3 +278,48 @@
 # See https://access.redhat.com/support/policy/updates/errata for EOL date (because it's a RHEL clone)
 {{ eurolinux(8, minpackages=5000, valid_till='2029-05-31', subrepos=['appstream', 'baseos', 'highavability', 'powertools', 'resilientstorage']) }}
 {{ eurolinux(9, minpackages=3000, valid_till='2032-05-31', subrepos=['appstream', 'baseos', 'highavailability', 'powertools', 'resilientstorage']) }}
+
+###########################################################################
+# MSVSphere
+###########################################################################
+{% macro msvsphere(version, minpackages, subrepos, valid_till=None) %}
+- name: msvsphere_{{version}}
+  type: repository
+  desc: MSVSphere {{version}}
+  statsgroup: CentOS
+  family: centos
+  ruleset: [centos, rpm]
+  color: 'b511bA'
+  minpackages: {{minpackages}}
+  {% if valid_till %}
+  valid_till: {{valid_till}}
+  {% endif %}
+  sources:
+    {% for sub in subrepos %}
+    - name: {{sub}}
+      fetcher:
+        class: RepodataFetcher
+        url: 'https://repo1.msvsphere-os.ru/vault/{{version}}/{{sub}}/sources/'
+      parser:
+        class: RepodataParser
+        vertags: el
+      subrepo: '{{sub}}'
+    {% endfor %}
+  repolinks:
+    - desc: MSVSphere home
+      url: https://msvsphere-os.ru/
+  packagelinks:
+    - type: PACKAGE_SOURCES
+      url: 'https://git.inferitos.ru/rpms/{srcname}/src/branch/i{{version}}c'
+    - type: PACKAGE_RECIPE
+      url: 'https://git.inferitos.ru/rpms/{srcname}/src/branch/i{{version}}c/SPECS/{srcname}.spec'
+    - type: PACKAGE_RECIPE_RAW
+      url: 'https://git.inferitos.ru/rpms/{srcname}/raw/branch/i{{version}}c/SPECS/{srcname}.spec'
+  groups: [ all, production, centos, rpm, msvsphere ]
+{% endmacro %}
+
+# See https://access.redhat.com/support/policy/updates/errata for EOL date (because it's a RHEL clone)
+# Release 8 coming soon
+#{{ msvsphere(8, minpackages=2500, valid_till='2029-05-31', subrepos=['AppStream','BaseOS','HighAvailability','NFV','PowerTools','RT','ResilientStorage','Extras']) }}
+{{ msvsphere(9, minpackages=2000, valid_till='2032-05-31', subrepos=['AppStream','BaseOS','CRB','HighAvailability','NFV','RT','ResilientStorage','Extras', 'LibreOffice']) }}
+

--- a/repos.d/rpm/centos.yaml
+++ b/repos.d/rpm/centos.yaml
@@ -308,6 +308,13 @@
   repolinks:
     - desc: MSVSphere home
       url: https://msvsphere-os.ru/
+  packagelinks:
+    - type: PACKAGE_SOURCES
+      url: 'https://git.inferitos.ru/rpms/{srcname}/src/branch/i{{version}}c'
+    - type: PACKAGE_RECIPE
+      url: 'https://git.inferitos.ru/rpms/{srcname}/src/branch/i{{version}}c/SPECS/{srcname}.spec'
+    - type: PACKAGE_RECIPE_RAW
+      url: 'https://git.inferitos.ru/rpms/{srcname}/raw/branch/i{{version}}c/SPECS/{srcname}.spec'
   groups: [ all, production, centos, rpm, msvsphere ]
 {% endmacro %}
 

--- a/repos.d/rpm/centos.yaml
+++ b/repos.d/rpm/centos.yaml
@@ -308,13 +308,6 @@
   repolinks:
     - desc: MSVSphere home
       url: https://msvsphere-os.ru/
-  packagelinks:
-    - type: PACKAGE_SOURCES
-      url: 'https://git.inferitos.ru/rpms/{srcname}/src/branch/i{{version}}c'
-    - type: PACKAGE_RECIPE
-      url: 'https://git.inferitos.ru/rpms/{srcname}/src/branch/i{{version}}c/SPECS/{srcname}.spec'
-    - type: PACKAGE_RECIPE_RAW
-      url: 'https://git.inferitos.ru/rpms/{srcname}/raw/branch/i{{version}}c/SPECS/{srcname}.spec'
   groups: [ all, production, centos, rpm, msvsphere ]
 {% endmacro %}
 

--- a/repos.d/rpm/centos.yaml
+++ b/repos.d/rpm/centos.yaml
@@ -322,4 +322,3 @@
 # Release 8 coming soon
 #{{ msvsphere(8, minpackages=2500, valid_till='2029-05-31', subrepos=['AppStream','BaseOS','HighAvailability','NFV','PowerTools','RT','ResilientStorage','Extras']) }}
 {{ msvsphere(9, minpackages=2000, valid_till='2032-05-31', subrepos=['AppStream','BaseOS','CRB','HighAvailability','NFV','RT','ResilientStorage','Extras', 'LibreOffice']) }}
-


### PR DESCRIPTION
Hello! Please add MSVSphere Distribution. It based on RHEL (like AlmaLinux and Rocky) but has many improvements, such as multimedia support, classic desktop look, additional software, GOST encryption, and others.

At this time released only 9 (9.4) version of MSVSphere. 8 (8.10) version comming soon in August.


Site: https://msvsphere-os.ru
git: https://git.inferitos.ru/rpms