### PR TITLE
parsers/spack: read categories and licenses

### DIFF
--- a/repology/parsers/parsers/spack.py
+++ b/repology/parsers/parsers/spack.py
@@ -35,6 +35,8 @@ class SpackJsonParser(Parser):
                 pkg.add_name(pkgdata['name'], NameType.SPACK_NAME)
                 pkg.add_homepages(pkgdata['homepages'])
                 pkg.add_maintainers(f'{m}@spack' for m in pkgdata['maintainers'])
+                pkg.add_categories(pkgdata['categories'])
+                pkg.add_licenses(pkgdata['licenses'])
                 pkg.set_extra_field('patch', [patch.split()[0] for patch in pkgdata['patches'] if '://' not in patch])
 
                 # - no usable keywords/categories (yet)


### PR DESCRIPTION
Spack [now](https://github.com/spack/packages.spack.io/pull/20) publishes categories and licenses in the [repology.json](https://raw.githubusercontent.com/spack/packages.spack.io/main/data/repology.json).

Disclaimers:
- Not all packages have a license. License can be `UNKNOWN`. License is recommended to be SPDX but not enforced. Not all licenses are checked (yet) by humans (and unchecked/checked licenses are both exported to `repology.json`). Since different versions are a key use case of spack, packages can include multiple licenses that apply to different version ranges, but the list is flattened in `repology.json`.
- Not all packages have a category. Packages can have multiple categories.

E.g. current output:
```
$ curl -L https://raw.githubusercontent.com/spack/packages.spack.io/main/data/repology.json | jq -S '.packages.[] | (.licenses, .categories)' | head -n50
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 17.5M  100 17.5M    0     0  10.2M      0  0:00:01  0:00:01 --:--:-- 10.2M
[
  "BSD-2-Clause"
]
[]
[
  "BSD-2-Clause"
]
[]
[]
[]
[]
[]
[
  "MIT"
]
[]
[
  "BSD-2-Clause"
]
[]
[
  "MIT"
]
[
  "rocm",
  "detectable"
]
[
  "LGPL-2.1-or-later"
]
[]
[
  "BSD-3-Clause"
]
[]
[
  "MIT"
]
[
  "ecp"
]
[]
[
  "rocm"
]
[
  "MIT"
]
```