### PR TITLE
Remove contrib subrepo from Chimera Linux repository

### DIFF
--- a/repos.d/alpine/chimera.yaml
+++ b/repos.d/alpine/chimera.yaml
@@ -13,7 +13,7 @@
   minpackages: 6000
   default_maintainer: fallback-mnt-chimera@repology
   sources:
-    {% for subrepo in ['main', 'contrib', 'user'] %}
+    {% for subrepo in ['main', 'user'] %}
     - name: {{subrepo}}
       fetcher:
         class: FileFetcher


### PR DESCRIPTION
According to Chimera Linux developers, the contrib subrepo is basically the same as the main subrepo, but with an arbitrary separation, and it has to be manually added when one installs Chimera Linux. The former has been merged into the latter.