### PR TITLE
fdroid: Add PACKAGE_RECIPE link

### DIFF
--- a/repos.d/fdroid.yaml
+++ b/repos.d/fdroid.yaml
@@ -24,4 +24,6 @@
       url: 'https://f-droid.org/packages/{srcname}/'
     - type: PACKAGE_BUILD_LOG_RAW
       url: 'https://f-droid.org/repo/{srcname}_{versioncode}.log.gz'
+    - type: PACKAGE_RECIPE
+      url: 'https://gitlab.com/fdroid/fdroiddata/-/blob/master/metadata/{srcname}.yml'
   groups: [ all, production ]


### PR DESCRIPTION
I noticed that https://repology.org/repository/fdroid has a banner stating:

> This repository [does not provide](https://repology.org/repositories/fields#fdroid) links to package recipes or sources in a way accessible by Repology. This is critical, because one of the goals of Repology is to make the details of how a project is packaged visible to anyone. It makes Repology maintenance harder as it's not possible to easily check where a specific version comes from; it does not allow upstream to check the recipe and improve their software to simplify packaging, or suggest corrections to the maintainer; it does not allow other maintainers to learn new ideas. It may be as well dangerous to users due to lack of transparency. Because of that, this repository is subject to removal in the near future.

This PR adds this missing data.