### PR TITLE
add nixos 24.11

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -43,6 +43,7 @@
 {{ nix('23.05', minpackages=90000, valid_till='2023-12-31') }}
 {{ nix('23.11', minpackages=90000, valid_till='2024-06-30') }}
 {{ nix('24.05', minpackages=100000, valid_till='2024-12-31') }}
+{{ nix('24.11', minpackages=100000, valid_till='2025-06-30') }}
 
 - name: nix_unstable
   type: repository


### PR DESCRIPTION
NixOS 24.11 just entered beta and is planned to be released on 22nd of November.