### PR TITLE
Add alpine 3.21

### DIFF
--- a/repos.d/alpine/alpine.yaml
+++ b/repos.d/alpine/alpine.yaml
@@ -81,4 +81,5 @@
 {{ alpine('3.18', minpackages=16000, valid_till='2025-05-09') }}
 {{ alpine('3.19', minpackages=16000, valid_till='2025-11-01') }}
 {{ alpine('3.20', minpackages=23000, valid_till='2026-04-01') }}
+{{ alpine('3.21', minpackages=24000, valid_till='2026-11-01') }}
 {{ alpine('edge', minpackages=23000, subrepos=['community', 'main', 'testing']) }}

--- a/repos.d/alpine/alpine.yaml
+++ b/repos.d/alpine/alpine.yaml
@@ -82,4 +82,4 @@
 {{ alpine('3.19', minpackages=16000, valid_till='2025-11-01') }}
 {{ alpine('3.20', minpackages=23000, valid_till='2026-04-01') }}
 {{ alpine('3.21', minpackages=24000, valid_till='2026-11-01') }}
-{{ alpine('edge', minpackages=23000, subrepos=['community', 'main', 'testing']) }}
+{{ alpine('edge', minpackages=31000, subrepos=['community', 'main', 'testing']) }}


### PR DESCRIPTION
## Summary

Alpine [release 3.21.0](https://alpinelinux.org/posts/Alpine-3.21.0-released.html) on 2024-12-05. [Archive](https://web.archive.org/web/20241205224528/https://alpinelinux.org/posts/Alpine-3.21.0-released.html).
It will be supported until [2026-11-01](https://alpinelinux.org/releases/). [Archive](https://web.archive.org/web/20241206081252/https://alpinelinux.org/releases/).

## Additional

Alpine 3.21 has
- 5536 in the main repository;
- 19847 in the community repository.
```sh
for name in {main,community}; do
  count="$(curl -s "https://dl-cdn.alpinelinux.org/alpine/v3.21/$name/x86_64/APKINDEX.tar.gz" | zgrep -cP '^P:')"
  echo "$name $count";
done
```

Alpine edge has
- 5544 in the main repository;
- 19863 in the community repository;
- 7280 in the testing repository.
```sh
for name in {main,community,testing}; do
  count="$(curl -s "https://dl-cdn.alpinelinux.org/alpine/edge/$name/x86_64/APKINDEX.tar.gz" | zgrep -cP '^P:')"
  echo "$name $count";
done
```