### PR TITLE
Remove dead homepage for Ataraxia GNU/Linux

### DIFF
--- a/repos.d/ataraxia.yaml
+++ b/repos.d/ataraxia.yaml
@@ -15,8 +15,6 @@
       parser:
         class: AtaraxiaJsonParser
   repolinks:
-    - desc: Ataraxia Linux home
-      url: https://ataraxialinux.org/
     - desc: Ataraxia Linux source repository
       url: https://gitlab.com/ataraxialinux/ataraxia/
   packagelinks:


### PR DESCRIPTION
Pretty simple; they clearly let their domain expire.