### PR TITLE
Fedora eols

### DIFF
--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -102,7 +102,7 @@
 {{ fedora(36, minpackages=24000, valid_till='2023-05-16', archived=True) }}
 {{ fedora(37, minpackages=21000, valid_till='2023-12-05', archived=True) }}
 {{ fedora(38, minpackages=21000, valid_till='2024-05-21', archived=True) }}
-{{ fedora(39, minpackages=21000, valid_till='2024-11-26') }}
+{{ fedora(39, minpackages=21000, valid_till='2024-11-26', archived=True) }}
 {{ fedora(40, minpackages=21000, valid_till='2025-05-28') }}
 {{ fedora(41, minpackages=21000, valid_till='2025-11-19') }}
 {# fedora(42, minpackages=21000, valid_till='????-??-??', development=True) #}

--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -98,12 +98,12 @@
 {{ fedora(32, minpackages=24000, valid_till='2021-05-25', archived=True) }}
 {{ fedora(33, minpackages=24000, valid_till='2021-11-30', archived=True) }}
 {{ fedora(34, minpackages=24000, valid_till='2022-06-07', archived=True) }}
-{{ fedora(35, minpackages=24000, valid_till='2022-11-15', archived=True) }}
+{{ fedora(35, minpackages=24000, valid_till='2022-12-13', archived=True) }}
 {{ fedora(36, minpackages=24000, valid_till='2023-05-16', archived=True) }}
-{{ fedora(37, minpackages=21000, valid_till='2023-11-14', archived=True) }}
-{{ fedora(38, minpackages=21000, valid_till='2024-05-14', archived=True) }}
-{{ fedora(39, minpackages=21000, valid_till='2024-11-12') }}
-{{ fedora(40, minpackages=21000, valid_till='2025-05-13') }}
-{{ fedora(41, minpackages=21000, valid_till='2025-12-01') }}
+{{ fedora(37, minpackages=21000, valid_till='2023-12-05', archived=True) }}
+{{ fedora(38, minpackages=21000, valid_till='2024-05-21', archived=True) }}
+{{ fedora(39, minpackages=21000, valid_till='2024-11-26') }}
+{{ fedora(40, minpackages=21000, valid_till='2025-05-28') }}
+{{ fedora(41, minpackages=21000, valid_till='2025-11-19') }}
 {# fedora(42, minpackages=21000, valid_till='????-??-??', development=True) #}
 {{ fedora('rawhide', minpackages=21000, development=True) }}


### PR DESCRIPTION
I wrote a small script to sync Fedora's eol dates between repology, Fedora's eol list, wikidata and endoflife.date in order to keep those correct over time, whenever new versions go eol. When I ran it, I noticed that the repology eol dates are off on a few occasions. (Same for endoflife.date and wikidata, but I already fixed those.) That is probably due to the fact that Fedora does not have fixed eol dates in advance and the Wikipedia pages is also outdated on some. (I may add that to my script in a next iteration.)

It may not be of relevance for repology for the past dates but it would make my life a bit easier to get those synced up, so that I have a better overview of matching vs mismatching dates in the future. I'm happy to provide updates on coming eol dates whenever I become aware of them.

Also I noticed that 39 is already eol for some time and on the archives mirror, I guess it is a good time to set the archived flag.