### PR TITLE
Remove outdated NixOS releases

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -37,12 +37,6 @@
   groups: [ all, production, nix ]
 {% endmacro %}
 
-{{ nix('21.11', minpackages=70000, valid_till='2022-06-30') }}
-{{ nix('22.05', minpackages=75000, valid_till='2022-12-31') }}
-{{ nix('22.11', minpackages=85000, valid_till='2023-06-30') }}
-{{ nix('23.05', minpackages=90000, valid_till='2023-12-31') }}
-{{ nix('23.11', minpackages=90000, valid_till='2024-06-30') }}
-{{ nix('24.05', minpackages=100000, valid_till='2024-12-31') }}
 {{ nix('24.11', minpackages=100000, valid_till='2025-06-30') }}
 
 - name: nix_unstable


### PR DESCRIPTION
NixOS 24.11 is the only one that is not EOL. The Nix community normally sunsets a release roughly a month after the next one goes into GA.