### PR TITLE
parsers: add ptxdist support

### DIFF
--- a/repology-schemacheck.py
+++ b/repology-schemacheck.py
@@ -104,6 +104,7 @@ families = [
     'pkgsrc',
     'pld',
     'postmarketos',
+    'ptxdist',
     'pypi',
     'ravenports',
     'reactos',

--- a/repology/packagemaker/names.py
+++ b/repology/packagemaker/names.py
@@ -211,6 +211,8 @@ class NameType:
 
     BUILDROOT_NAME: ClassVar[int] = GENERIC_SRC_NAME
 
+    PTXDIST_NAME: ClassVar[int] = GENERIC_SRC_NAME
+
     MSYS2_NAME: ClassVar[int] = GENERIC_NOBN_NAME
     MSYS2_BASENAME: ClassVar[int] = GENERIC_NOBN_BASENAME
 

--- a/repology/parsers/parsers/ptxdist.py
+++ b/repology/parsers/parsers/ptxdist.py
@@ -1,0 +1,40 @@
+# Copyright (C) 2025 Bruno Thomsen <bruno.thomsen@gmail.com>
+#
+# This file is part of repology
+#
+# repology is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# repology is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with repology.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Iterable
+
+from repology.packagemaker import NameType, PackageFactory, PackageMaker
+from repology.package import LinkType
+from repology.parsers import Parser
+from repology.parsers.json import iter_json_list
+
+
+class PtxdistJsonParser(Parser):
+    def iter_parse(self, path: str, factory: PackageFactory) -> Iterable[PackageMaker]:
+        for pkgdata in iter_json_list(path, (None,)):
+            # Based on Chromebrew (removed summary and homepages)
+            # repology/parsers/parsers/chromebrew.py
+            # https://raw.githubusercontent.com/chromebrew/chromebrew/master/tools/repology.json
+
+            # PTXdist JSON output:
+            # https://raw.githubusercontent.com/baxeno/ptxdist-repology/refs/heads/main/repology.json
+            with factory.begin() as pkg:
+                pkg.add_name(pkgdata['name'], NameType.PTXDIST_NAME)
+                pkg.set_version(pkgdata['version'])
+                pkg.add_links(LinkType.UPSTREAM_DOWNLOAD, pkgdata['upstream_urls'].split(' '))
+                pkg.add_licenses(pkgdata['license'])
+                yield pkg

--- a/repos.d/ptxdist.yaml
+++ b/repos.d/ptxdist.yaml
@@ -1,0 +1,27 @@
+###########################################################################
+# PTXdist
+###########################################################################
+- name: ptxdist
+  type: repository
+  desc: PTXdist
+  family: ptxdist
+  ruleset: ptxdist
+  minpackages: 900
+  sources:
+    - name: repology.json
+      fetcher:
+        class: FileFetcher
+        url: https://raw.githubusercontent.com/baxeno/ptxdist-repology/refs/heads/main/repology.json
+      parser:
+        class: PtxdistJsonParser
+  repolinks:
+    - desc: PTXdist home
+      url: https://ptxdist.de/
+    - desc: PTXdist repository
+      url: https://git.pengutronix.de/cgit/ptxdist
+  packagelinks:
+    - type: PACKAGE_RECIPE
+      url: 'https://git.pengutronix.de/cgit/ptxdist/tree/rules/{srcname}.make'
+    - type: PACKAGE_RECIPE_RAW
+      url: 'https://git.pengutronix.de/cgit/ptxdist/plain/rules/{srcname}.make'
+  groups: [ all, production ]


### PR DESCRIPTION
ptxdist is a distribution that targets embedded Linux image builds similar to buildroot and yocto.

This is an early POC version of PTXdist support where JSON format is generated with a RFC PATCH for ptxdist.

JSON format is similar to chromebrew.

Resolves #1487
