### PR TITLE
Fix packages with nix teams not showing up

### DIFF
--- a/repology/parsers/parsers/nix.py
+++ b/repology/parsers/parsers/nix.py
@@ -219,6 +219,13 @@ class NixJsonParser(Parser):
                     else:
                         pkg.add_maintainers(extract_nix_maintainers(meta['maintainers']))
 
+                if 'teams' in meta:
+                    if not isinstance(meta['teams'], list):
+                        pkg.log('teams "{}" is not a list'.format(meta['teams']), severity=Logger.ERROR)
+                    else:
+                        for item in meta['teams']:
+                            pkg.add_maintainers(extract_nix_maintainers(item['members']))
+
                 if 'license' in meta:
                     pkg.add_licenses(extract_nix_licenses(meta['license']))
 


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/394797 added a new `meta.teams` attribute to packages in nix, https://github.com/NixOS/nixpkgs/pull/400458 switched everything to use it. Without this fix, packages which use `meta.teams` do not show ownership on repology.