### PR TITLE
Remove default maintainer from Chimera

### DIFF
--- a/repos.d/alpine/chimera.yaml
+++ b/repos.d/alpine/chimera.yaml
@@ -11,7 +11,6 @@
   family: chimera
   ruleset: chimera
   minpackages: 6000
-  default_maintainer: fallback-mnt-chimera@repology
   sources:
     {% for subrepo in ['main', 'user'] %}
     - name: {{subrepo}}


### PR DESCRIPTION
chimera no longer has the concept of maintainers as of https://github.com/chimera-linux/cports/commit/910fcf1054398f95eb6b215dd702867d99edf250 so there's not much sense for a maintainer field to exist anymore