### PR TITLE
Update Fedora 40 EOL date

### DIFF
--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -102,7 +102,7 @@
 {{ fedora(37, minpackages=21000, valid_till='2023-12-05', archived=True) }}
 {{ fedora(38, minpackages=21000, valid_till='2024-05-21', archived=True) }}
 {{ fedora(39, minpackages=21000, valid_till='2024-11-26', archived=True) }}
-{{ fedora(40, minpackages=21000, valid_till='2025-05-28') }}
+{{ fedora(40, minpackages=21000, valid_till='2025-05-13') }}
 {{ fedora(41, minpackages=21000, valid_till='2025-11-19') }}
 {{ fedora(42, minpackages=21000, valid_till='2026-05-13') }}
 {# fedora(43, minpackages=21000, valid_till='2026-12-02', development=True) #}


### PR DESCRIPTION
Source: https://lists.fedoraproject.org/archives/list/announce@lists.fedoraproject.org/thread/D453IDELL5ABDCLFAH344J4B5MBJGMVR/

The archive is not ready yet, therefore I didn't set the archvies flag. (https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/40/ is 404)