### PR TITLE
add NixOS 25.05

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -48,6 +48,7 @@
 {{ nix('23.11', minpackages=90000, valid_till='2024-06-30') }}
 {{ nix('24.05', minpackages=100000, valid_till='2024-12-31') }}
 {{ nix('24.11', minpackages=100000, valid_till='2025-06-30', build_logs=True) }}
+{{ nix('25.05', minpackages=100000, valid_till='2025-12-31', build_logs=True) }}
 
 - name: nix_unstable
   type: repository


### PR DESCRIPTION
NixOS 25.05 is planned to be release on the 2025-05-23 and is currently in beta.


For more info, see: https://github.com/NixOS/nixpkgs/issues/390768