### PR TITLE
AOSC: Support PyPI sources and add link for version checker

### DIFF
--- a/repology/parsers/parsers/aosc.py
+++ b/repology/parsers/parsers/aosc.py
@@ -71,6 +71,9 @@ class AoscPkgsParser(Parser):
                     pkg.add_links(LinkType.UPSTREAM_REPOSITORY, pkgdata['srcurl'])
                 elif srctype == 'Tarball':
                     pkg.add_links(LinkType.UPSTREAM_DOWNLOAD, pkgdata['srcurl'])
+                elif srctype == 'PyPI':
+                    pypi_url = 'https://pypi.org/project/{}/'.format(pkgdata['srcurl'])
+                    pkg.add_links(LinkType.UPSTREAM_HOMEPAGE, pypi_url)
 
                 # just a committer, doesn't seem suitable
                 #pkg.add_maintainers(extract_maintainers(pkgdata['committer']))

--- a/repology/parsers/parsers/aosc.py
+++ b/repology/parsers/parsers/aosc.py
@@ -67,7 +67,7 @@ class AoscPkgsParser(Parser):
                 pkg.set_summary(pkgdata['description'])
 
                 srctype = pkgdata['srctype']
-                if srctype == 'Git' or srctype == 'Svn' or srctype == 'Bzr':
+                if srctype == 'Git' or srctype == 'SvnSrc' or srctype == 'BzrSrc':
                     pkg.add_links(LinkType.UPSTREAM_REPOSITORY, pkgdata['srcurl'])
                 elif srctype == 'Tarball':
                     pkg.add_links(LinkType.UPSTREAM_DOWNLOAD, pkgdata['srcurl'])

--- a/repos.d/aosc.yaml
+++ b/repos.d/aosc.yaml
@@ -17,15 +17,17 @@
       parser:
         class: AoscPkgsParser
   repolinks:
-    - desc: AOSC OS home
+    - desc: AOSC home
       url: https://aosc.io/
-    - desc: AOSC packages
+    - desc: AOSC OS packages
       url: https://packages.aosc.io/
   packagelinks:
     - type: PACKAGE_HOMEPAGE
       url: 'https://packages.aosc.io/packages/{binname}'
     - type: PACKAGE_SOURCES
       url: 'https://github.com/AOSC-Dev/{tree}/tree/{branch}/{srcname}'
+    - type: PACKAGE_NEW_VERSION_CHECKER
+      url: 'https://anicca.aosc.io/?search={binname}'
     # These are broken for 73% of packages - recipe may reside in different directory than 'autobuild'
     #- type: PACKAGE_RECIPE
     #  url: 'https://github.com/AOSC-Dev/{tree}/blob/{branch}/{srcname}/autobuild/build'


### PR DESCRIPTION
This PR fixes the support for SVN and BZR sources, adds support for PyPI sources (which was newly introduced months ago) and adds links to the Anicca version checker.
