### PR TITLE
re-enable pacstall in `production`

### DIFF
--- a/repos.d/pacstall.yaml
+++ b/repos.d/pacstall.yaml
@@ -19,4 +19,4 @@
       url: https://pacstall.dev/
     - desc: Default pacscripts repository
       url: https://github.com/pacstall/pacstall-programs
-  groups: [ all ]
+  groups: [ all, production ]


### PR DESCRIPTION
Last year, Pacstall was removed from the production branch in https://github.com/repology/repology-updater/commit/70c2a744df1f351c09203efb5839eee4d3f757c1:

> Some `url` fields became null:
```
  {
    "name": "cmake-data-deb",
    "visibleName": "Cmake Data",
    "description": "CMake data files (modules, templates and documentation)",
    "maintainer": {
      "name": "Zahrun",
      "email": "Zahrun@github.com"
    },
    "version": "3.25.1",
    "url": null,
    "recipeUrl": "https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packages/cmake-data-deb/cmake-data-deb.pacscript",
    "packageDetailsUrl": "https://pacstall.dev/packages/cmake-data-deb",
    "type": "Debian Native",
    "patches": []
  },
```

This issue arose due to the fact that Pacstall had been in the process of a transition to [architecture-](https://github.com/pacstall/pacstall/releases/tag/5.0.0) and [distribution-extended](https://github.com/pacstall/pacstall/releases/tag/5.1.0) arrays, in the same vein as [Arch Linux does with their PKGBUILDs](https://wiki.archlinux.org/title/PKGBUILD#source). The API had not been properly updated to reflect this change when it went live in the package repository, but it should have been dealt with before.

---

Since then, two more major changes have occured. First, the API was updated to use object types that can handle these extended arrays (see `ArchDistroString` on our [API docs](https://swagger.pacstall.dev/)) for the `url` value. Second, Pacstall introduced static `.SRCINFO` handling of data for packages, also in line with PKGBUILDs, where the API has been updated to parse from these files instead of Pacscripts themselves.

These two changes, combined with more strict validation checks, eliminates any chance for transient values like before, with a significantly more robust system overall. `null` values no longer have the possibility to exist on our `/api/repology` endpoint - the only value of note is `maintainer`, which may be an empty array (`"maintainer": []`) for orphaned packages.

---

This is a request to get Pacstall back on `production`, now that these issues have been resolved. The full spec for our updated repology endpoint is available on our [Swagger docs](https://swagger.pacstall.dev/#/repology) with the `RepologyPackage` schema, but all of the values remain unchanged except for the two mentioned above, `url` and `maintainer`, which have turned into arrays, as well as the removal of the deprecated `patches` array. Here is an example:
```
 {
    "name": "docker-bin",
    "visibleName": "Docker",
    "description": "Docker Engine Static Binaries",
    "maintainer": [
      {
        "name": "Oren Klopfer",
        "email": "oren@taumoda.com"
      }
    ],
    "version": "28.2.2-1",
    "url": [
      {
        "arch": "arm64",
        "value": "https://download.docker.com/linux/static/stable/aarch64/docker-28.2.2.tgz"
      },
      {
        "arch": "amd64",
        "value": "https://download.docker.com/linux/static/stable/x86_64/docker-28.2.2.tgz"
      }
    ],
    "recipeUrl": "https://raw.githubusercontent.com/pacstall/pacstall-programs/master/packages/docker-bin/docker-bin.pacscript",
    "packageDetailsUrl": "https://pacstall.dev/packages/docker-bin",
    "type": "Precompiled"
  },
  ```

We hope to be more transparent in communicating these things in the future, including notifying of plans to make major changes to either the package repository or the API, so that any concerns can be brought up before these issues arise.

Should any arise despite this, please do not hesitate to contact us at pacstall@pm.me, our [Discord](https://discord.gg/yzrjXJV6K8), or file an issue on the [website repo](https://github.com/pacstall/website), so that we can address them swiftly, before Pacstall must be taken off of `production` again.