### PR TITLE
nix: Don't exclude team members

### DIFF
--- a/repology/parsers/parsers/nix.py
+++ b/repology/parsers/parsers/nix.py
@@ -221,11 +221,6 @@ class NixJsonParser(Parser):
                 if 'maintainers' in meta:
                     maintainers = set(extract_nix_maintainers(meta['maintainers']))
 
-                    team_maintainers: set[str] = set()
-                    for team in meta.get('teams', []):
-                        team_maintainers.update(extract_nix_maintainers(team['members']))
-                    maintainers -= team_maintainers
-
                     if len(maintainers) > 12:
                         raise RuntimeError(f'too many maintainers ({len(maintainers)}: {", ".join(sorted(maintainers))}) for a single package')
 


### PR DESCRIPTION
This partially reverts 3fb04fa66f02377c26dab6fd747168a38d60d361.

As noted in https://github.com/repology/repology-updater/issues/1497#issuecomment-2899308391 the addition of `meta.teams` to `meta.maintainers` was just a return to the status quo before the introduction of separate field. In the long run it makes sense to handle teams as single entities but while it isn't implemented let's leave them as is, since some people rely on this (https://github.com/NixOS/nixpkgs/pull/402991#issuecomment-2853221104).

FWIW the largest team in nixpkgs counts 10 members so most of the team owned packages will likely still be under the limit.