### PR TITLE
exherbo: update urls to exherbo.org

### DIFF
--- a/repos.d/exherbo.yaml
+++ b/repos.d/exherbo.yaml
@@ -18,9 +18,9 @@
         class: ExherboJsonParser
   repolinks:
     - desc: Exherbo home
-      url: https://www.exherbolinux.org/
+      url: https://www.exherbo.org/
     - desc: Exherbo packages
-      url: https://summer.exherbolinux.org/
+      url: https://summer.exherbo.org/
   packagelinks:
     - type: PACKAGE_HOMEPAGE
       url: 'https://summer.exherbo.org/packages/{srcname}/index.html'


### PR DESCRIPTION
* At long last, we got our main domain back, revert back to using exherbo.org
* Fixes usage of current redirects (exherbolinux.org -> exherbo.org)