### PR TITLE
Add deepin 25 repositories

### DIFF
--- a/repos.d/deb/deepin.yaml
+++ b/repos.d/deb/deepin.yaml
@@ -53,3 +53,32 @@
     - type: PACKAGE_SOURCES
       url: 'https://github.com/deepin-community/{srcname}'
   groups: [ all, production, deepin ]
+
+- name: deepin_25
+  type: repository
+  desc: deepin 25
+  statsgroup: Debian+derivs
+  family: debuntu
+  ruleset: [ debuntu, deepin ]
+  color: '949393'
+  minpackages: 8000
+  update_period: 1w
+  pessimized: "does not provide access (HTTP 404) to package sources (for instance, https://repology.org/link/https://github.com/deepin-community/linux)"
+  sources:
+    - name: [ main, community, commercial ]
+      fetcher:
+        class: FileFetcher
+        url: 'https://cdn-community-packages.deepin.com/deepin/beige/dists/crimson/{source}/source/Sources.gz'
+        compression: gz
+      parser:
+        class: DebianSourcesParser
+      subrepo: '{source}'
+  repolinks:
+    - desc: deepin home
+      url: https://www.deepin.org/
+    - desc: deepin open build service instance
+      url: https://build.deepin.com/
+  packagelinks:
+    - type: PACKAGE_SOURCES
+      url: 'https://github.com/deepin-community/{srcname}'
+  groups: [ all, production, deepin ]


### PR DESCRIPTION
Note: deepin 25's repo url path indeed still contain the word `beige` (which is the codename for deepin 23), it is not a typo.