### PR TITLE
Enable rosa13

### DIFF
--- a/repos.d/rpm/rosa.yaml
+++ b/repos.d/rpm/rosa.yaml
@@ -73,4 +73,4 @@
       url: 'https://abf.io/import/{srcname}/blob/rosa2023.1/{srcname}.spec'
     - type: PACKAGE_RECIPE_RAW
       url: 'https://abf.io/import/{srcname}/raw/rosa2023.1/{srcname}.spec'
-  groups: [ all, rosa ]
+  groups: [ all, production, rosa ]


### PR DESCRIPTION
At the moment, rosa13 is a live platform for the distribution of Rosa Fresh.
It is where the latest releases are released Rosa Fresh.