### PR TITLE
Add trixie-backports and bookworm-backports-sloppy

### DIFF
--- a/repos.d/deb/debian.yaml
+++ b/repos.d/deb/debian.yaml
@@ -166,7 +166,7 @@
 # list of repos and backports https://packages.debian.org/stable/
 {{ debian(11, 'bullseye', minpackages=30000, valid_till='2026-08-31') }}
 {{ debian(12, 'bookworm', minpackages=33000, valid_till='2028-06-30', backports=True) }}
-{{ debian(13, 'trixie',   minpackages=36000, valid_till='2030-06-30') }}
+{{ debian(13, 'trixie',   minpackages=36000, valid_till='2030-06-30', backports=True) }}
 {{ debian(14, 'forky',    minpackages=36000, valid_till='2032-06-30') }} # EoL assumed
 
 # Rolling

--- a/repos.d/deb/debian.yaml
+++ b/repos.d/deb/debian.yaml
@@ -165,7 +165,7 @@
 # pages: https://buildd.debian.org/status/package.php?p=0ad-data&suite=jessie
 # list of repos and backports https://packages.debian.org/stable/
 {{ debian(11, 'bullseye', minpackages=30000, valid_till='2026-08-31') }}
-{{ debian(12, 'bookworm', minpackages=33000, valid_till='2028-06-30', backports=True) }}
+{{ debian(12, 'bookworm', minpackages=33000, valid_till='2028-06-30', backports=True, backports_sloppy=True) }}
 {{ debian(13, 'trixie',   minpackages=36000, valid_till='2030-06-30', backports=True) }}
 {{ debian(14, 'forky',    minpackages=36000, valid_till='2032-06-30') }} # EoL assumed
 


### PR DESCRIPTION
See also https://backports.debian.org/news/trixie-backports_available/