### PR TITLE
pypi: Fix confusion between falsy and UPSTREAM_HOMEPAGE

### DIFF
--- a/repology/parsers/parsers/pypi.py
+++ b/repology/parsers/parsers/pypi.py
@@ -90,7 +90,7 @@ class PyPiCacheJsonParser(Parser):
 
                 if info['project_urls']:
                     for key, url in info['project_urls'].items():
-                        if (link_type := _url_types.get(key.lower())) and url != 'UNKNOWN':
+                        if (link_type := _url_types.get(key.lower())) is not None and url != 'UNKNOWN':
                             pkg.add_links(link_type, url)
 
                 for version, releasedatas in pkgdata['releases'].items():


### PR DESCRIPTION
This dropped all URLs of type "UPSTREAM_HOMEPAGE" before.

This fixes homepage links for projects which got rid of the legacy URL fields and only use modern metadata (see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls).
