### PR TITLE
Add deepin 25 repositories

### DIFF
--- a/repos.d/deb/deepin.yaml
+++ b/repos.d/deb/deepin.yaml
@@ -57,3 +57,34 @@
     - type: PACKAGE_SOURCES
       url: 'https://github.com/deepin-community/{srcname}'
   groups: [ all, production, deepin ]
+
+- name: deepin_25
+  type: repository
+  desc: deepin 25
+  statsgroup: Debian+derivs
+  family: debuntu
+  ruleset: [ debuntu, deepin ]
+  color: '949393'
+  minpackages: 8000
+  update_period: 1w
+  pessimized: "does not provide access (HTTP 404) to package sources (for instance, https://repology.org/link/https://github.com/deepin-community/linux)"
+  sources:
+    {% for sub in ['main', 'community', 'commercial' ] %}
+    - name: {{sub}}
+      fetcher:
+        class: FileFetcher
+        url: 'https://community-packages.deepin.com/deepin/beige/dists/crimson/{{sub}}/source/Sources.gz'
+        compression: gz
+      parser:
+        class: DebianSourcesParser
+      subrepo: {{sub}}
+    {% endfor %}
+  repolinks:
+    - desc: deepin home
+      url: https://www.deepin.org/
+    - desc: deepin open build service instance
+      url: https://build.deepin.com/
+  packagelinks:
+    - type: PACKAGE_SOURCES
+      url: 'https://github.com/deepin-community/{srcname}'
+  groups: [ all, production, deepin ]


### PR DESCRIPTION
Use the same PACKAGE_SOURCES as Deepin 23; the only difference is that Deepin 23 might provide an older version of the package.