### PR TITLE
Update Fedora 41 eol date

### DIFF
--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -91,7 +91,7 @@
 {{ fedora(38, minpackages=21000, valid_till='2024-05-21', archived=True) }}
 {{ fedora(39, minpackages=21000, valid_till='2024-11-26', archived=True) }}
 {{ fedora(40, minpackages=21000, valid_till='2025-05-13', archived=True) }}
-{{ fedora(41, minpackages=21000, valid_till='2025-11-19') }}
+{{ fedora(41, minpackages=21000, valid_till='2025-11-26') }}
 {{ fedora(42, minpackages=21000, valid_till='2026-05-13') }}
 {{ fedora(43, minpackages=21000, valid_till='2026-12-02') }}
 {# fedora(44, minpackages=21000, valid_till='2027-05-19', development=True) #}


### PR DESCRIPTION
Source: https://pagure.io/fedora-pgm/schedule/issue/218