### PR TITLE
Add terra 42 & 43.

### DIFF
--- a/repos.d/rpm/terra.yaml
+++ b/repos.d/rpm/terra.yaml
@@ -1,7 +1,7 @@
 ###########################################################################
 # Terra
 ###########################################################################
-{% macro terra(version, minpackages) %}
+{% macro terra(version, minpackages, valid_till) %}
 - name: terra_{{version}}
   type: repository
   desc: Terra {{version}}
@@ -10,6 +10,9 @@
   minpackages: {{minpackages}}
   update_period: 1w
   pessimized: "does not provide access (HTTP 404) to package sources (for instance, https://repology.org/link/https://madoguchi.fyralabs.com/redirect/terrarawhide/packages/wingpanel-indicator-nightlight-debugsource)"
+  {% if valid_till %}
+  valid_till: {{valid_till}}
+  {% endif %}
   sources:
     # Note: terra contains packages build in different ways, see
     # https://github.com/repology/repology-updater/issues/1307 for some details
@@ -58,6 +61,9 @@
   groups: [ all, production, terra ]
 {% endmacro %}
 
-{{ terra(42, 500) }}
-{{ terra(43, 500) }}
+{{ terra(39, 500, valid_till='2024-11-26') }}
+{{ terra(40, 500, valid_till='2025-05-13') }}
+{{ terra(41, 500, valid_till='2025-11-26') }}
+{{ terra(42, 500, valid_till='2026-05-13') }}
+{{ terra(43, 500, valid_till='2026-12-02') }}
 {{ terra('rawhide', 500) }}


### PR DESCRIPTION
The broken sources links should be fixed on rawhide and supported versions. I checked rawhide today and 42/43 should work as well. If anything seems broken on 42 or 43, it's likely an orphan package from before I applied a patch to our package tracker, please let me know!