### PR TITLE
Revert "nix_unstable: disable due to broken data (#1565)"

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -74,4 +74,4 @@
   packagelinks:
     - type: PACKAGE_RECIPE
       url: 'https://github.com/NixOS/nixpkgs/blob/nixos-unstable/{?posfile}#L{?posline}'
-  groups: [ all, have_testdata, nix ]
+  groups: [ all, production, have_testdata, nix ]


### PR DESCRIPTION
This reverts commit ceb86e40f2661530e9d51b974f7d3b39e7ccd16c.

This resolves #1565 because NixOS/nixpkgs#480323 has been merged as a workaround to provide pname and version for packages lacking their explicit definition.