### PR TITLE
Implement MARKED_BROKEN flag for OpenBSD packages

### DIFF
--- a/repology/package.py
+++ b/repology/package.py
@@ -87,6 +87,7 @@ class PackageFlags:
     NOLEGACY: ClassVar[int] = 1 << 18
     OUTDATED: ClassVar[int] = 1 << 19
     RECALLED: ClassVar[int] = 1 << 20
+    MARKED_BROKEN: ClassVar[int] = 1 << 21
 
     ANY_IGNORED: ClassVar[int] = IGNORE | INCORRECT | UNTRUSTED | NOSCHEME
 
@@ -133,6 +134,7 @@ class PackageFlags:
                 PackageFlags.NOLEGACY: 'NOLEGACY',
                 PackageFlags.OUTDATED: 'OUTDATED',
                 PackageFlags.RECALLED: 'RECALLED',
+                PackageFlags.MARKED_BROKEN: 'MARKED_BROKEN',
             }.items() if val & var
         )
 

--- a/sql.d/update/update_vulnerabilities.sql
+++ b/sql.d/update/update_vulnerabilities.sql
@@ -20,6 +20,7 @@ SET
 	flags = flags | (1 << 16)
 WHERE
 	versionclass != 10 -- ROLLING
+	AND (flags & (1 << 21)) = 0 -- MARKED_BROKEN
 	AND EXISTS (
 		SELECT *
 		FROM vulnerable_projects


### PR DESCRIPTION
Body: This PR introduces a new package flag to handle OpenBSD ports marked as BROKEN.

Changes:
- Added PackageFlags.MARKED_BROKEN (1 << 21).
- Updated OpenBSD parser (openbsd.py) to set this flag when the Broken column is populated in sql ports .
- Modified : update_vulnerabilities.sql to exclude packages with this flag from vulnerability statistics.