### PR TITLE
Security: Potential SQL injection via unsanitized SQL construction

### DIFF
--- a/repology/parsers/sqlite.py
+++ b/repology/parsers/sqlite.py
@@ -15,11 +15,22 @@
 # You should have received a copy of the GNU General Public License
 # along with repology.  If not, see <http://www.gnu.org/licenses/>.
 
+import re
 import sqlite3
 from typing import Any, Iterable, Sequence
 
 
 def iter_sqlite(path: str, table_expr: str, columns: Sequence[str]) -> Iterable[dict[str, Any]]:
+    identifier_re = re.compile(r'^[A-Za-z_][A-Za-z0-9_]*$')
+
+    if not identifier_re.fullmatch(table_expr):
+        raise ValueError('invalid table name')
+
+    for column in columns:
+        if not identifier_re.fullmatch(column):
+            raise ValueError('invalid column name')
+
+    conn = None
     try:
         conn = sqlite3.connect('file:{}?mode=ro'.format(path))
         cur = conn.cursor()


### PR DESCRIPTION
## Summary

Security: Potential SQL injection via unsanitized SQL construction

## Problem

**Severity**: `Medium` | **File**: `repology/parsers/sqlite.py:L24`

`iter_sqlite` builds SQL using string formatting for `table_expr` and `columns` (`SELECT {} FROM {}`). If either argument is derived from untrusted input (directly or indirectly via configuration), attackers can inject arbitrary SQL into the query.

## Solution

Avoid dynamic SQL where possible. For identifiers (table/column names), enforce strict allowlists or regex validation (e.g., `^[A-Za-z_][A-Za-z0-9_]*$`) and map user-facing values to predefined safe SQL fragments.

## Changes

- `repology/parsers/sqlite.py` (modified)