### PR TITLE
nix: track nixpkgs-unstable instead of nixos-unstable

### DIFF
--- a/repos.d/nixos.yaml
+++ b/repos.d/nixos.yaml
@@ -62,7 +62,7 @@
     - name: packages-unstable.json
       fetcher:
         class: FileFetcher
-        url: https://channels.nixos.org/nixos-unstable/packages.json.br
+        url: https://channels.nixos.org/nixpkgs-unstable/packages.json.br
       parser:
         class: NixJsonParser
         use_pname: true
@@ -75,5 +75,5 @@
       url: https://github.com/NixOS/nixpkgs
   packagelinks:
     - type: PACKAGE_RECIPE
-      url: 'https://github.com/NixOS/nixpkgs/blob/nixos-unstable/{?posfile}#L{?posline}'
+      url: 'https://github.com/NixOS/nixpkgs/blob/nixpkgs-unstable/{?posfile}#L{?posline}'
   groups: [ all, production, have_testdata, nix ]


### PR DESCRIPTION
The nixpkgs-unstable branch better reflects package versions built than the nixos-unstable branch can. This is because we run lots of tests on nixos-unstable and it often has multiple days of delay.

Currently, nixpkgs-unstable gets evaluated every 8 hours or 3 times per day. The major difference here is that nixpkgs also contains packages built for Darwin.

https://hydra.nixos.org/jobset/nixpkgs/unstable (vs https://hydra.nixos.org/jobset/nixos/unstable)
https://channels.nixos.org/nixpkgs-unstable
https://github.com/NixOS/nixpkgs/tree/nixpkgs-unstable

This chart shows the age before a new channel versions appears for both:

<img width="1404" height="262" alt="image" src="https://github.com/user-attachments/assets/d4219f79-bea5-41ff-bc50-c762ec38e86d" />

On average this will update at least once a day down from every two to three days.
