### PR TITLE
Add XRepo (xmake-repo) repository support

### DIFF
--- a/repology-schemacheck.py
+++ b/repology-schemacheck.py
@@ -134,6 +134,7 @@ families = [
     'wakemeops',
     'wikidata',
     'winget',
+    'xrepo',
     'yacp',
     'yiffos',
 ]

--- a/repology/packagemaker/names.py
+++ b/repology/packagemaker/names.py
@@ -252,6 +252,8 @@ class NameType:
 
     OPAM_NAME: ClassVar[int] = GENERIC_SRC_NAME
 
+    XREPO_NAME: ClassVar[int] = GENERIC_SRC_NAME
+
 
 @dataclass
 class _NameMapping:

--- a/repology/parsers/parsers/xrepo.py
+++ b/repology/parsers/parsers/xrepo.py
@@ -1,0 +1,58 @@
+# Copyright (C) 2026 Dmitry Marakasov <amdmi3@amdmi3.ru>
+#
+# This file is part of repology
+#
+# repology is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# repology is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with repology.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Iterable
+
+from repology.package import LinkType
+from repology.packagemaker import NameType, PackageFactory, PackageMaker
+from repology.parsers import Parser
+from repology.parsers.json import iter_json_list
+
+
+def _normalize_version(version: str) -> str:
+    if version.startswith('v') and len(version) > 1 and version[1].isdigit():
+        return version[1:]
+    return version
+
+
+class XrepoJsonParser(Parser):
+    def iter_parse(self, path: str, factory: PackageFactory) -> Iterable[PackageMaker]:
+        for pkgdata in iter_json_list(path, ('packages', None)):
+            name = pkgdata.get('name')
+            version = pkgdata.get('version')
+            if not name or not version:
+                continue
+
+            with factory.begin(name) as pkg:
+                pkg.add_name(name, NameType.XREPO_NAME)
+                pkg.set_version(version, _normalize_version)
+                pkg.set_extra_field('xrepo_package_path', f'packages/{name[0]}/{name}')
+
+                if (summary := pkgdata.get('description')):
+                    pkg.set_summary(summary)
+                if (homepage := pkgdata.get('homepage')):
+                    pkg.add_links(LinkType.UPSTREAM_HOMEPAGE, homepage)
+                if (license_ := pkgdata.get('license')):
+                    pkg.add_licenses(license_)
+                if (repo_url := pkgdata.get('repository_url')):
+                    pkg.add_links(LinkType.UPSTREAM_REPOSITORY, repo_url)
+
+                download_url = pkgdata.get('download_url')
+                if download_url and not download_url.endswith('.git'):
+                    pkg.add_links(LinkType.UPSTREAM_DOWNLOAD, download_url)
+
+                yield pkg

--- a/repology/parsers/parsers/xrepo.py
+++ b/repology/parsers/parsers/xrepo.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2026 Dmitry Marakasov <amdmi3@amdmi3.ru>
+# Copyright (C) 2026 Aleksandr Kovalko <gistrec@gmail.com>
 #
 # This file is part of repology
 #

--- a/repology/parsers/parsers/xrepo.py
+++ b/repology/parsers/parsers/xrepo.py
@@ -23,36 +23,19 @@ from repology.parsers import Parser
 from repology.parsers.json import iter_json_list
 
 
-def _normalize_version(version: str) -> str:
-    if version.startswith('v') and len(version) > 1 and version[1].isdigit():
-        return version[1:]
-    return version
-
-
 class XrepoJsonParser(Parser):
     def iter_parse(self, path: str, factory: PackageFactory) -> Iterable[PackageMaker]:
         for pkgdata in iter_json_list(path, ('packages', None)):
-            name = pkgdata.get('name')
-            version = pkgdata.get('version')
-            if not name or not version:
-                continue
-
-            with factory.begin(name) as pkg:
+            with factory.begin() as pkg:
+                name = pkgdata['name']
                 pkg.add_name(name, NameType.XREPO_NAME)
-                pkg.set_version(version, _normalize_version)
+                pkg.set_version(pkgdata['version'])
                 pkg.set_extra_field('xrepo_package_path', f'packages/{name[0]}/{name}')
 
-                if (summary := pkgdata.get('description')):
-                    pkg.set_summary(summary)
-                if (homepage := pkgdata.get('homepage')):
-                    pkg.add_links(LinkType.UPSTREAM_HOMEPAGE, homepage)
-                if (license_ := pkgdata.get('license')):
-                    pkg.add_licenses(license_)
-                if (repo_url := pkgdata.get('repository_url')):
-                    pkg.add_links(LinkType.UPSTREAM_REPOSITORY, repo_url)
-
-                download_url = pkgdata.get('download_url')
-                if download_url and not download_url.endswith('.git'):
-                    pkg.add_links(LinkType.UPSTREAM_DOWNLOAD, download_url)
+                pkg.set_summary(pkgdata.get('description'))
+                pkg.add_links(LinkType.UPSTREAM_HOMEPAGE, pkgdata.get('homepage'))
+                pkg.add_licenses(pkgdata.get('license'))
+                pkg.add_links(LinkType.UPSTREAM_REPOSITORY, pkgdata.get('repository_url'))
+                pkg.add_links(LinkType.UPSTREAM_DOWNLOAD, pkgdata.get('download_url'))
 
                 yield pkg

--- a/repology/parsers/parsers/xrepo.py
+++ b/repology/parsers/parsers/xrepo.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2026 Aleksandr Kovalko <gistrec@gmail.com>
+#
+# This file is part of repology
+#
+# repology is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# repology is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with repology.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Iterable
+
+from repology.package import LinkType
+from repology.packagemaker import NameType, PackageFactory, PackageMaker
+from repology.parsers import Parser
+from repology.parsers.json import iter_json_list
+
+
+class XrepoJsonParser(Parser):
+    def iter_parse(self, path: str, factory: PackageFactory) -> Iterable[PackageMaker]:
+        for pkgdata in iter_json_list(path, ('packages', None)):
+            if 'base' in pkgdata:
+                continue
+
+            with factory.begin() as pkg:
+                pkg.add_name(pkgdata['name'], NameType.XREPO_NAME)
+
+                pkg.set_summary(pkgdata.get('description'))
+                pkg.add_links(LinkType.UPSTREAM_HOMEPAGE, pkgdata.get('homepage'))
+                pkg.add_licenses(pkgdata.get('license'))
+                pkg.add_links(LinkType.UPSTREAM_REPOSITORY, pkgdata.get('repository_url'))
+
+                latest_version = pkgdata['version']
+
+                for version in pkgdata.get('versions') or [latest_version]:
+                    verpkg = pkg.clone()
+                    verpkg.set_version(version)
+
+                    if version == latest_version:
+                        verpkg.add_links(LinkType.UPSTREAM_DOWNLOAD, pkgdata.get('download_urls') or pkgdata.get('download_url'))
+
+                    patches = [patch for patch in pkgdata.get('patches', []) if f'/patches/{version}/' in patch]
+                    if patches:
+                        verpkg.set_extra_field('patch', patches)
+
+                    yield verpkg

--- a/repos.d/xrepo.yaml
+++ b/repos.d/xrepo.yaml
@@ -1,0 +1,29 @@
+###########################################################################
+# xrepo (xmake-repo)
+###########################################################################
+- name: xrepo
+  type: repository
+  desc: xrepo
+  family: xrepo
+  ruleset: xrepo
+  minpackages: 1500
+  sources:
+    - name: repology_packages_index.json
+      fetcher:
+        class: FileFetcher
+        url: https://xmake-io.github.io/xmake-repo/repology_packages_index.json
+      parser:
+        class: XrepoJsonParser
+  repolinks:
+    - desc: xrepo website
+      url: https://xrepo.xmake.io/
+    - desc: xmake-repo on GitHub
+      url: https://github.com/xmake-io/xmake-repo
+  packagelinks:
+    - type: PACKAGE_SOURCES
+      url: 'https://github.com/xmake-io/xmake-repo/tree/dev/{xrepo_package_path}'
+    - type: PACKAGE_RECIPE
+      url: 'https://github.com/xmake-io/xmake-repo/blob/dev/{xrepo_package_path}/xmake.lua'
+    - type: PACKAGE_RECIPE_RAW
+      url: 'https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/{xrepo_package_path}/xmake.lua'
+  groups: [ all, production ]

--- a/repos.d/xrepo.yaml
+++ b/repos.d/xrepo.yaml
@@ -1,0 +1,33 @@
+###########################################################################
+# xrepo (xmake-repo)
+###########################################################################
+- name: xrepo
+  type: repository
+  desc: xrepo
+  family: xrepo
+  ruleset: xrepo
+  minpackages: 1500
+  sources:
+    - name: repology_packages_index.json
+      fetcher:
+        class: FileFetcher
+        url: https://xmake-io.github.io/xmake-repo/repology_packages_index.json
+      parser:
+        class: XrepoJsonParser
+  repolinks:
+    - desc: xrepo website
+      url: https://xrepo.xmake.io/
+    - desc: xmake-repo on GitHub
+      url: https://github.com/xmake-io/xmake-repo
+  packagelinks:
+    - type: PACKAGE_SOURCES
+      url: 'https://github.com/xmake-io/xmake-repo/tree/dev/packages/{srcname|first_letter}/{srcname}'
+    - type: PACKAGE_RECIPE
+      url: 'https://github.com/xmake-io/xmake-repo/blob/dev/packages/{srcname|first_letter}/{srcname}/xmake.lua'
+    - type: PACKAGE_RECIPE_RAW
+      url: 'https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/packages/{srcname|first_letter}/{srcname}/xmake.lua'
+    - type: PACKAGE_PATCH
+      url: 'https://github.com/xmake-io/xmake-repo/blob/dev/{?patch}'
+    - type: PACKAGE_PATCH_RAW
+      url: 'https://raw.githubusercontent.com/xmake-io/xmake-repo/dev/{?patch}'
+  groups: [ all, production, have_testdata ]

--- a/testdata/xrepo.state
+++ b/testdata/xrepo.state
@@ -1,0 +1,32 @@
+{
+  "count": 3,
+  "generated_at": "2026-05-19T00:00:00Z",
+  "packages": [
+    {
+      "name": "abseil",
+      "version": "20260107.1",
+      "description": "C++ Common Libraries",
+      "download_url": "https://github.com/abseil/abseil-cpp/archive/refs/tags/20260107.1.tar.gz",
+      "repository_url": "https://github.com/abseil/abseil-cpp",
+      "homepage": "https://abseil.io",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "ada",
+      "version": "v3.4.4",
+      "description": "WHATWG-compliant and fast URL parser written in modern C++",
+      "download_url": "https://github.com/ada-url/ada/archive/refs/tags/v3.4.4.tar.gz",
+      "repository_url": "https://github.com/ada-url/ada",
+      "homepage": "https://www.ada-url.com",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "alcatraz",
+      "version": "2023.07.14",
+      "description": "x64 binary obfuscator",
+      "download_url": "https://github.com/weak1337/Alcatraz.git",
+      "homepage": "https://github.com/weak1337/Alcatraz",
+      "repository_url": "https://github.com/weak1337/Alcatraz"
+    }
+  ]
+}

--- a/testdata/xrepo.state/repology_packages_index.json
+++ b/testdata/xrepo.state/repology_packages_index.json
@@ -1,0 +1,62 @@
+{
+  "count": 5,
+  "generated_at": "2026-08-15T00:00:00Z",
+  "packages": [
+    {
+      "name": "abseil",
+      "version": "20260107.1",
+      "versions": ["20250512.1", "20260107.1"],
+      "description": "C++ Common Libraries",
+      "download_url": "https://github.com/abseil/abseil-cpp/archive/refs/tags/20260107.1.tar.gz",
+      "download_urls": ["https://github.com/abseil/abseil-cpp/archive/refs/tags/20260107.1.tar.gz"],
+      "repository_url": "https://github.com/abseil/abseil-cpp",
+      "homepage": "https://abseil.io",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "ada",
+      "version": "v3.4.4",
+      "versions": ["v3.4.4"],
+      "description": "WHATWG-compliant and fast URL parser written in modern C++",
+      "download_url": "https://github.com/ada-url/ada/archive/refs/tags/v3.4.4.tar.gz",
+      "download_urls": [
+        "https://github.com/ada-url/ada/archive/refs/tags/v3.4.4.tar.gz",
+        "https://mirror.example.org/ada/ada-3.4.4.tar.gz"
+      ],
+      "repository_url": "https://github.com/ada-url/ada",
+      "homepage": "https://www.ada-url.com",
+      "license": "Apache-2.0"
+    },
+    {
+      "name": "alcatraz",
+      "version": "2023.07.14",
+      "versions": ["2023.07.14"],
+      "description": "x64 binary obfuscator",
+      "homepage": "https://github.com/weak1337/Alcatraz",
+      "repository_url": "https://github.com/weak1337/Alcatraz"
+    },
+    {
+      "name": "7z",
+      "version": "21.02",
+      "versions": ["19.00", "21.02"],
+      "description": "A file archiver with a high compression ratio.",
+      "download_url": "https://github.com/xmake-mirror/7zip/archive/refs/tags/21.02.tar.gz",
+      "download_urls": ["https://github.com/xmake-mirror/7zip/archive/refs/tags/21.02.tar.gz"],
+      "repository_url": "https://github.com/xmake-mirror/7zip.git",
+      "homepage": "https://www.7-zip.org/",
+      "patches": ["packages/7/7z/patches/21.02/backport-21.03-fix-for-GCC-10.patch"]
+    },
+    {
+      "name": "curl",
+      "version": "8.21.0",
+      "versions": ["8.21.0"],
+      "base": "libcurl",
+      "description": "The multiprotocol file transfer library.",
+      "download_url": "https://curl.haxx.se/download/curl-8.21.0.tar.bz2",
+      "download_urls": ["https://curl.haxx.se/download/curl-8.21.0.tar.bz2"],
+      "repository_url": "https://github.com/curl/curl",
+      "homepage": "https://curl.haxx.se/",
+      "license": "curl"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds support for [xrepo / xmake-repo](https://github.com/xmake-io/xmake-repo), the C/C++ package repository for the [xmake](https://xmake.io/) build system. Similar in spirit to the vcpkg and conan integrations.

This is an alternative to #1585 — it consumes the pre-built static index that xmake-repo publishes specifically for Repology:

  - https://xmake-io.github.io/xmake-repo/repology_packages_index.json

The JSON already contains everything we need per package (`name`, `version`, `description`, `license`, `homepage`, `repository_url`, `download_url`), so we just reuse the existing `FileFetcher` instead of writing a custom fetcher that fans out to a separate API + per-package `xmake.lua` scrapes.

Verified end-to-end against the live index — **1905 packages** parse cleanly (with 1588 licenses, 1894 homepages, 1690 repository links, 1455 download links).

## Changes

- `repos.d/xrepo.yaml` — repository definition, points `FileFetcher` at the static JSON
- `repology/parsers/parsers/xrepo.py` — `XrepoJsonParser` streaming the `packages[]` array via `iter_json_list`
- `repology/packagemaker/names.py` — `XREPO_NAME` (maps to `GENERIC_SRC_NAME`)
- `repology-schemacheck.py` — adds `xrepo` to known families
- `testdata/xrepo.state` — small sample index for local checks

`xrepo_package_path` (used in `PACKAGE_SOURCES` / `PACKAGE_RECIPE` / `PACKAGE_RECIPE_RAW` link templates) is derived from the `packages/{first-letter}/{name}/` convention used by xmake-repo, since the static index doesn't include it. All three generated link types resolve against the live `dev` branch.

Leading `v` is stripped from versions like `v3.4.4` → `3.4.4`. `.git` `download_url`s (e.g. `…/repo.git`) are not added as `UPSTREAM_DOWNLOAD` links since they're VCS URLs, not archives.
