### PR TITLE
Expand Salix coverage: add 15.0, i486, extra/xfce subrepos

### DIFF
--- a/repos.d/salix.yaml
+++ b/repos.d/salix.yaml
@@ -1,6 +1,35 @@
 ###########################################################################
 # Salix
 ###########################################################################
+
+{% set salix_mirror = "https://download.salixos.org" %}
+
+- name: salix_15_0
+  type: repository
+  desc: Salix 15.0
+  family: salix
+  ruleset: salix
+  color: '7ad37a'
+  minpackages: 600
+  sources:
+    {% for arch in ['x86_64', 'i486'] %}
+    {% for sub in [{'name': 'main', 'dir': '15.0'}, {'name': 'extra', 'dir': 'extra-15.0'}, {'name': 'xfce', 'dir': 'xfce4.18-15.0'}] %}
+    - name: {{arch}}-{{sub.name}}
+      fetcher:
+        class: FileFetcher
+        url: '{{salix_mirror}}/{{arch}}/{{sub.dir}}/PACKAGES.json'
+      parser:
+        class: SalixPackagesJsonParser
+      subrepo: {{sub.name}}
+    {% endfor %}
+    {% endfor %}
+  repolinks:
+    - desc: Salix home
+      url: https://www.salixos.org/
+    - desc: Salix package search
+      url: https://packages.salixos.org/
+  groups: [ all, production, salix ]
+
 - name: salix_14_2
   type: repository
   desc: Salix 14.2
@@ -9,13 +38,17 @@
   color: '7ad37a'
   minpackages: 600
   sources:
-    - name: x86_64-PACKAGES.json
+    {% for arch in ['x86_64', 'i486'] %}
+    {% for sub in [{'name': 'main', 'dir': '14.2'}, {'name': 'extra', 'dir': 'extra-14.2'}] %}
+    - name: {{arch}}-{{sub.name}}
       fetcher:
         class: FileFetcher
-        url: 'https://download.salixos.org/x86_64/14.2/PACKAGES.json'
+        url: '{{salix_mirror}}/{{arch}}/{{sub.dir}}/PACKAGES.json'
       parser:
         class: SalixPackagesJsonParser
-    # XXX: add 32 bit repo
+      subrepo: {{sub.name}}
+    {% endfor %}
+    {% endfor %}
   repolinks:
     - desc: Salix home
       url: https://www.salixos.org/


### PR DESCRIPTION
This should expand Salix coverage:

- Adds Salix 15.0 (previously only 14.2 was tracked).
- Adds the i486 architecture alongside x86_64 for both 14.2 and 15.0 (resolves the existing `# XXX: add 32 bit repo` note in `salix.yaml`).
- Adds the Salix-native `extra` sub-repository for both versions, and
  the `xfce` sub-repository (`xfce4.18`) for 15.0.

This is related to #1346 (cc @gapan) but a narrower scope. I didn't exercise the database write step locally.