### PR TITLE
Fix reactos parser on Python 3.12+ (ConfigParser.readfp removed)

### DIFF
--- a/repology/parsers/parsers/reactos.py
+++ b/repology/parsers/parsers/reactos.py
@@ -34,7 +34,7 @@ class RappsParser(Parser):
                 config = configparser.ConfigParser(interpolation=None)
 
                 with open(os.path.join(path, filename), 'r', encoding='utf_8_sig') as f:
-                    config.readfp(f)  # type: ignore
+                    config.read_file(f)
 
                 section = config['Section']
 


### PR DESCRIPTION
ConfigParser.readfp() was deprecated in Python 3.2 and removed in Python 3.12. On 3.12+ the reactos (rapps) parser raises AttributeError: 'ConfigParser' object has no attribute 'readfp', which fails parsing and drops the entire reactos repository.

Replace it with read_file() - the direct, semantically identical replacement available since Python 3.2. The # type: ignore is dropped since read_file() is properly typed.