### PR TITLE
openvsx: paginate search API (?size=10000 now returns 400)

### DIFF
--- a/repology/fetchers/fetchers/openvsx.py
+++ b/repology/fetchers/fetchers/openvsx.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2024 Dmitry Marakasov <amdmi3@amdmi3.ru>
+#
+# This file is part of repology
+#
+# repology is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# repology is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with repology.  If not, see <http://www.gnu.org/licenses/>.
+
+import json
+import os
+import time
+from itertools import count
+
+from repology.atomic_fs import AtomicDir
+from repology.fetchers import PersistentData, ScratchDirFetcher
+from repology.fetchers.http import PoliteHTTP
+from repology.logger import Logger
+
+
+class OpenVSXFetcher(ScratchDirFetcher):
+    def __init__(self, url: str, page_size: int = 1000, fetch_timeout: int = 60, fetch_delay: int | None = None, max_tries: int = 5, retry_delay: int = 5) -> None:
+        self.url = url
+        self.page_size = page_size
+        self.do_http = PoliteHTTP(timeout=fetch_timeout, delay=fetch_delay)
+        self.max_tries = max_tries
+        self.retry_delay = retry_delay
+
+    def _do_fetch_retry(self, url: str, logger: Logger) -> str:
+        num_try = 1
+        while True:
+            try:
+                return self.do_http(url).text
+            except ConnectionError as e:
+                if num_try >= self.max_tries:
+                    raise
+                logger.log(f'failed to fetch {url}: {e}, retrying after delay...', Logger.ERROR)
+                time.sleep(self.retry_delay)
+                num_try += 1
+
+    def _do_fetch(self, statedir: AtomicDir, persdata: PersistentData, logger: Logger) -> bool:
+        page_counter = count()
+        total_size: int | None = None
+        num_fetched = 0
+        offset = 0
+
+        while True:
+            url = f'{self.url}?offset={offset}&size={self.page_size}&sortBy=timestamp&sortOrder=asc'
+            logger.log(f'fetching {url}')
+
+            text = self._do_fetch_retry(url, logger)
+            data = json.loads(text)
+
+            if total_size is None:
+                total_size = data['totalSize']
+                logger.log(f'{total_size} extension(s) to fetch')
+
+            extensions = data.get('extensions', [])
+            if not extensions:
+                break
+
+            with open(os.path.join(statedir.get_path(), f'{next(page_counter)}.json'), 'w', encoding='utf-8') as pagefile:
+                pagefile.write(text)
+                pagefile.flush()
+                os.fsync(pagefile.fileno())
+
+            num_fetched += len(extensions)
+            offset += self.page_size
+
+            if offset >= total_size:
+                break
+
+        if total_size is not None and num_fetched != total_size:
+            logger.log(f'fetched {num_fetched} extension(s), but API reported {total_size}', Logger.WARNING)
+
+        logger.log(f'fetched {num_fetched} extension(s)')
+        return True

--- a/repology/parsers/parsers/openvsx.py
+++ b/repology/parsers/parsers/openvsx.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with repology.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 from typing import Iterable
 
 from repology.package import LinkType
@@ -25,6 +26,10 @@ from repology.parsers.json import iter_json_list
 
 class OpenVSXParser(Parser):
     def iter_parse(self, path: str, factory: PackageFactory) -> Iterable[PackageMaker]:
+        for pagename in os.listdir(path):
+            yield from self._iter_parse_page(os.path.join(path, pagename), factory)
+
+    def _iter_parse_page(self, path: str, factory: PackageFactory) -> Iterable[PackageMaker]:
         for extension in iter_json_list(path, ('extensions', None)):
             with factory.begin() as pkg:
                 # TODO: More metadata is available, it's just harder to fetch and will require its own fetcher, in all likelihood

--- a/repos.d/modules/openvsx.yaml
+++ b/repos.d/modules/openvsx.yaml
@@ -3,7 +3,8 @@
 ###########################################################################
 # NOTE: API returns more data for individual packages, including upstream
 # url. Unfortunately, we cannot fetch individual API output for every package
-# Also if ?size=10000 breaks at some point, we'll have to disable this
+# The search API caps ?size at 1000, so OpenVSXFetcher pages through it by
+# offset.
 - name: openvsx
   type: modules
   desc: Open VSX
@@ -11,11 +12,10 @@
   ruleset: openvsx
   minpackages: 3500
   sources:
-    - name: search.json
+    - name: search
       fetcher:
-        class: FileFetcher
-        url: https://open-vsx.org/api/-/search?size=10000
-        allow_zero_size: false
+        class: OpenVSXFetcher
+        url: https://open-vsx.org/api/-/search
       parser:
         class: OpenVSXParser
   shadow: true


### PR DESCRIPTION
OpenVSX now rejects large ?size (max 1000), so the single-shot fetch 400s and the whole repo drops. Page by offset with a stable timestamp sort; write pages verbatim like the crates.io fetcher.