### PR TITLE
Archive Fedora 42 in fedora.yaml

### DIFF
--- a/repos.d/rpm/fedora.yaml
+++ b/repos.d/rpm/fedora.yaml
@@ -90,7 +90,7 @@
 {{ fedora(39, minpackages=21000, valid_till='2024-11-26', archived=True) }}
 {{ fedora(40, minpackages=21000, valid_till='2025-05-13', archived=True) }}
 {{ fedora(41, minpackages=21000, valid_till='2025-12-15', archived=True) }}
-{{ fedora(42, minpackages=21000, valid_till='2026-05-27') }}
+{{ fedora(42, minpackages=21000, valid_till='2026-05-27', archived=True) }}
 {{ fedora(43, minpackages=21000, valid_till='2026-12-09') }}
 {{ fedora(44, minpackages=21000, valid_till='2027-05-19') }}
 {{ fedora('rawhide', minpackages=21000, development=True) }}


### PR DESCRIPTION
Mark Fedora 42 as archived in the configuration.