### PR TITLE
Add deb.griffo.io repository

### DIFF
--- a/repos.d/deb/griffo.yaml
+++ b/repos.d/deb/griffo.yaml
@@ -1,0 +1,27 @@
+###########################################################################
+# deb.griffo.io
+###########################################################################
+- name: deb_griffo_io
+  type: repository
+  desc: deb.griffo.io
+  family: deb_griffo_io
+  ruleset: deb_griffo_io
+  color: 'd70a53'
+  minpackages: 30
+  sources:
+    {% for sub in ['bookworm', 'trixie', 'forky', 'sid', 'jammy', 'noble', 'questing', 'resolute'] %}
+    - name: {{sub}}
+      fetcher:
+        class: FileFetcher
+        url: 'https://deb.griffo.io/apt/dists/{{sub}}/main/binary-amd64/Packages.gz'
+        compression: gz
+      parser:
+        class: DebianPackagesParser
+      subrepo: {{sub}}
+    {% endfor %}
+  repolinks:
+    - desc: deb.griffo.io home
+      url: https://deb.griffo.io/
+    - desc: GitHub repository
+      url: https://github.com/dariogriffo/debian.griffo.io
+  groups: [ all, production ]


### PR DESCRIPTION
This adds [deb.griffo.io](https://deb.griffo.io/), an unofficial Debian/Ubuntu repository I maintain, providing the latest upstream versions of ~35 popular development tools (zig, zls, ghostty, helix, uv, eza, lazygit, yazi, zellij, starship, atuin, jujutsu, k9s, headscale, garage, tigerbeetle, bun, deno, ...) as properly packaged .deb files, rebuilt automatically within hours of upstream releases.

**Data:**
- Main github repo with links to all packaging process (one repo per package) https://github.com/dariogriffo/debian.griffo.io
- Standard Debian repository layout, `Packages.gz` per suite: e.g. https://deb.griffo.io/apt/dists/trixie/main/binary-amd64/Packages.gz
- 8 suites configured as subrepos: Debian bookworm/trixie/forky/sid, Ubuntu jammy/noble/questing/resolute (~43 packages on amd64 in trixie)
- 42/43 packages carry `Homepage:` fields pointing at upstream
- Config follows the `wakemeops.yaml` pattern (FileFetcher + DebianPackagesParser)
- Each package is built in a public GitHub repo with CI (`github.com/dariogriffo/<tool>-debian`)

A few packages use variant names (`zig-stable`, `zig-0`, `zls-0`, `ghostty-tip`, `bun-one`, `bun-profile`) — happy to follow up with name-mapping rules in repology-rules if you'd like them merged into their parent projects, or adjust anything else about the config.