### PR TITLE
pypi: skip release versions containing newlines

### DIFF
--- a/repology/parsers/parsers/pypi.py
+++ b/repology/parsers/parsers/pypi.py
@@ -95,6 +95,10 @@ class PyPiCacheJsonParser(Parser):
                             pkg.add_links(link_type, url)
 
                 for version, releasedatas in pkgdata['releases'].items():
+                    if "\n" in version or "\r" in version:
+                        pkg.log(f"Skipping malformed PyPI release version {version!r}", severity=Logger.WARNING)
+                        continue
+
                     verpkg = pkg.clone()
 
                     verpkg.set_version(version)


### PR DESCRIPTION
## What

Skip PyPI release versions whose version string contains a `\n` or `\r`, logging a warning rather than producing a malformed package entry.

## Why

Some packages on PyPI expose release keys with embedded newline/carriage-return characters in the version string. These leak through the parser and cause malformed package data downstream. Filtering them at the parse stage keeps the rest of the package's releases intact while dropping only the bad entries.