### PR TITLE
Add latest-debs repository

### DIFF
--- a/repos.d/deb/latest_debs.yaml
+++ b/repos.d/deb/latest_debs.yaml
@@ -1,0 +1,27 @@
+###########################################################################
+# latest-debs
+###########################################################################
+- name: latest_debs
+  type: repository
+  desc: latest-debs
+  family: debuntu
+  ruleset: debuntu
+  color: '1f6feb'
+  minpackages: 20
+  sources:
+    - name: bookworm/amd64
+      fetcher:
+        class: FileFetcher
+        url: 'https://latest-debs.github.io/apt-repo/dists/bookworm/main/binary-amd64/Packages.gz'
+        compression: gz
+      parser:
+        class: DebianPackagesParser
+  repolinks:
+    - desc: latest-debs home
+      url: https://latest-debs.github.io/
+    - desc: latest-debs GitHub organization
+      url: https://github.com/latest-debs
+  packagelinks:
+    - type: PACKAGE_SOURCES
+      url: 'https://github.com/latest-debs/{binname}-debian'
+  groups: [ all, production ]


### PR DESCRIPTION
## Summary

Adds [latest-debs](https://github.com/latest-debs), a signed apt repository
of current upstream releases for developer CLI tools, packaged for Debian
Bookworm/Trixie/Forky/Sid across multiple architectures.

- Home: https://latest-debs.github.io/
- Org: https://github.com/latest-debs
- Repo layout: standard reprepro-style `dists/<suite>/main/binary-<arch>/Packages.gz`, GPG-signed
- Every release is lintian-checked, smoke-tested in a container, and
  provenance-pinned (upstream SHA-256 cross-checked against the vendor's
  published checksum) before publishing — see
  [Supply chain & provenance](https://github.com/latest-debs/apt-repo#supply-chain--provenance)

The definition sources from `bookworm/main/binary-amd64`, currently 25
packages (ripgrep, bat, fd, fzf, starship, uv, bun, deno, duckdb,
lazygit, and others), reusing the existing `debuntu` ruleset like other
third-party apt repos in this tree (e.g. `deb-multimedia`, `wakemeops`).

## Note on maturity

Flagging this upfront rather than leaving it for review to discover: the
org is new (created 2026-08-11) and currently has one maintainer. The
pipeline, signing, and package builds are live and working, but there's
no long track record yet. Happy to adjust `minpackages` or hold off if
that's a concern from a maintenance-burden perspective — open to
guidance either way.