### PR TITLE
xrepo: switch index to canonical URL at packages.xmake.io

### DIFF
--- a/repos.d/xrepo.yaml
+++ b/repos.d/xrepo.yaml
@@ -11,7 +11,7 @@
     - name: repology_packages_index.json
       fetcher:
         class: FileFetcher
-        url: https://xmake-io.github.io/xmake-repo/repology_packages_index.json
+        url: https://packages.xmake.io/repology_packages_index.json
       parser:
         class: XrepoJsonParser
   repolinks:


### PR DESCRIPTION
Follow-up to #1594. Switches the xrepo index fetch to its canonical home, as agreed with the xmake maintainer (xmake-io/xmake-packages-index#2).

`https://packages.xmake.io/repology_packages_index.json` is published by [xmake-io/xmake-packages-index](https://github.com/xmake-io/xmake-packages-index), rebuilt hourly by the same generator that produced the old gh-pages copy. Verified today that both URLs serve identical content (1976 packages, identical name sets). The publishing pipeline also has a sanity check that refuses to deploy a truncated or empty index.

The old `xmake-io.github.io/xmake-repo` gh-pages copy will keep updating until this lands, and will be retired afterwards.